### PR TITLE
Improve FileIOMicro benchmark visualization

### DIFF
--- a/scripts/plot_file_io_benchmark_results.py
+++ b/scripts/plot_file_io_benchmark_results.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 #
-# Takes a FileIO benchmark output csv and plots read/write filesize against needed iterations for different I/O types.
-# Expects a benchmark csv as created by running FileIOReadMicroBenchmark and FileIOWriteMicroBenchmark with `--benchmark_format=csv`.
+# Takes a FileIO benchmark output csv and plots read/write filesize against throughput in MB/s.
+# Expects a benchmark csv as created by running FileIOReadMicroBenchmark and FileIOWriteMicroBenchmark with
+# `--benchmark_format=csv`.
+# To get a plot with error bars/statistical information simply supply a csv with multiple measurements for
+# a <benchmark_type/filesize> combination. This can be achieved e.g. by using the `--benchmark_repetitions=x` argument.
 #
 
 import pandas as pd
@@ -17,9 +20,15 @@ plt.style.use('ggplot')
 if len(sys.argv) != 2:
     sys.exit("Usage: " + sys.argv[0] + " benchmark.csv")
 
+#TODO: make pretty with arguments if statistical evaluation should be done
+
 with open(sys.argv[1]) as csv_file:
     df = pd.read_csv(csv_file)
     df[['fixture', 'type', 'filesize_mb']] = df['name'].str.split('/', 2, expand=True)
+
+    #drop rows containing pre-calculated statistical data (if provided)
+    df.drop(df[df.filesize_mb.str.contains('_mean|_median|_stddev|_cv')].index, inplace=True)
+
     df['filesize_mb'] = pd.to_numeric(df['filesize_mb'])
     df['real_time_sec'] = df['real_time'] / 1000000000
     df['mb_per_sec'] =  df['filesize_mb'] / df['real_time_sec']
@@ -27,9 +36,11 @@ with open(sys.argv[1]) as csv_file:
 benchmark_results = sns.barplot(data=df,
                                  x='filesize_mb',
                                  y='mb_per_sec',
-                                 hue='type')
+                                 hue='type',
+                                 capsize=.1,
+                                 errwidth=1)
 
-benchmark_results.set(xlabel ='Filesize in MB', ylabel = 'MB/s', title ='Different I/O method speed dependent on filesize')
+benchmark_results.set(xlabel ='Filesize in MB', ylabel = 'Throughput in MB/s', title ='Different I/O method speed dependent on filesize')
 
 plt.legend(title='I/O Type')
 plt.show()

--- a/scripts/plot_file_io_benchmark_results.py
+++ b/scripts/plot_file_io_benchmark_results.py
@@ -22,16 +22,12 @@ with open(sys.argv[1]) as csv_file:
     df[['fixture', 'type', 'filesize_mb']] = df['name'].str.split('/', 2, expand=True)
     df['filesize_mb'] = pd.to_numeric(df['filesize_mb'])
     df['real_time_sec'] = df['real_time'] / 1000000000
-    df['mb_per_sec'] = df['filesize_mb'] / df['real_time_sec']
+    df['mb_per_sec'] =  df['filesize_mb'] / df['real_time_sec']
 
-benchmark_results = sns.lineplot(data=df,
+benchmark_results = sns.barplot(data=df,
                                  x='filesize_mb',
                                  y='mb_per_sec',
-                                 hue='type',
-                                 marker='o')
-
-# make file size axis logarithmic
-benchmark_results.set(xscale='log', xticks=df['filesize_mb'], xticklabels=df['filesize_mb'])
+                                 hue='type')
 
 benchmark_results.set(xlabel ='Filesize in MB', ylabel = 'MB/s', title ='Different I/O method speed dependent on filesize')
 


### PR DESCRIPTION
To improve our generated visualization this PRs switches from line charts to bar plots and allows for plotting CSVs with statistical data aka multiple values for the same -> benchmark_type/filesize combination.

Such a file can be generated for example by:

`./hyriseMicroIOWriteBenchmark --benchmark_repetitions=3 --benchmark_format=csv > write_file_io_benchmark.csv`

And the visualization script can then be used like: (from hyrise root)

`python3 scripts/plot_file_io_benchmark_results.py cmake-build-debug/write_file_io_benchmark.csv`


![image](https://user-images.githubusercontent.com/34538290/200381577-a1d83c4c-a633-45a3-ba14-31e39c665331.png)
