### PR TITLE
Implemented in memory benchmark and imrpoved read benchmarks 

### DIFF
--- a/scripts/plot_file_io_benchmark_results.py
+++ b/scripts/plot_file_io_benchmark_results.py
@@ -10,31 +10,26 @@ import sys
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-#set plot styles
-sns.set_style('whitegrid')
-plt.style.use('ggplot')
+# set plot styles
+sns.set_style("whitegrid")
+plt.style.use("ggplot")
 
 if len(sys.argv) != 2:
     sys.exit("Usage: " + sys.argv[0] + " benchmark.csv")
 
 with open(sys.argv[1]) as csv_file:
     df = pd.read_csv(csv_file)
-    df[['fixture', 'type', 'filesize_mb']] = df['name'].str.split('/', 2, expand=True)
-    df['filesize_mb'] = pd.to_numeric(df['filesize_mb'])
-    df['real_time_sec'] = df['real_time'] / 1000000000
-    df['mb_per_sec'] = df['filesize_mb'] / df['real_time_sec']
+    df[["fixture", "type", "filesize_mb"]] = df["name"].str.split("/", 2, expand=True)
+    df["filesize_mb"] = pd.to_numeric(df["filesize_mb"])
+    df["real_time_sec"] = df["real_time"] / 1000000000
+    df["mb_per_sec"] = df["filesize_mb"] / df["real_time_sec"]
 
-benchmark_results = sns.lineplot(data=df,
-                                 x='filesize_mb',
-                                 y='mb_per_sec',
-                                 hue='type',
-                                 marker='o')
+benchmark_results = sns.lineplot(data=df, x="filesize_mb", y="mb_per_sec", hue="type", marker="o")
 
 # make file size axis logarithmic
-benchmark_results.set(xscale='log', xticks=df['filesize_mb'], xticklabels=df['filesize_mb'])
+benchmark_results.set(xscale="log", xticks=df["filesize_mb"], xticklabels=df["filesize_mb"])
 
-benchmark_results.set(xlabel ='Filesize in MB', ylabel = 'MB/s', title ='Different I/O method speed dependent on filesize')
+benchmark_results.set(xlabel="Filesize in MB", ylabel="MB/s", title="Different I/O method speed dependent on filesize")
 
-plt.legend(title='I/O Type')
+plt.legend(title="I/O Type")
 plt.show()
-

--- a/scripts/plot_file_io_benchmark_results.py
+++ b/scripts/plot_file_io_benchmark_results.py
@@ -2,7 +2,8 @@
 
 #
 # Takes a FileIO benchmark output csv and plots read/write filesize against needed iterations for different I/O types.
-# Expects a benchmark csv as created by running FileIOReadMicroBenchmark and FileIOWriteMicroBenchmark with `--benchmark_format=csv`.
+# Expects a benchmark csv as created by running FileIOReadMicroBenchmark and FileIOWriteMicroBenchmark with
+# `--benchmark_format=csv`.
 #
 
 import pandas as pd

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -98,34 +98,25 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)(benchmark::S
   }
 
   for (auto _ : state) {
- //   auto sum = uint64_t{0};
+    auto sum = uint64_t{0};
     uint64_t summand;
 
-/*    for (auto iterator = contents.cbegin(); iterator < contents.end(); ++iterator) {
-      summand = *iterator;
+    for(auto index = size_t{0}; index<contents.size();index++){
+      summand = contents[index];
       state.PauseTiming();
       sum += summand;
       state.ResumeTiming();
-    }*/
-    const auto last = contents.end();
-    // auto sum = uint64_t{0};
-    for (auto first = contents.cbegin(); first != last; ++first) {
-      summand = *first;
-      (void) summand;
-      state.PauseTiming();
-      // sum = std::move(sum) + summand;
-      state.ResumeTiming();
-
     }
+
     state.PauseTiming();
-   // Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
     state.ResumeTiming();
   }
 }
 
 //arguments are file size in MB
-// BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
-// BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)->Arg(10)->Arg(100)->Arg(1000);
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -84,8 +84,48 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)(benchmark::Sta
   }
 }
 
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)(benchmark::State& state) {// open file
+  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+
+  std::vector<uint64_t> contents(NUMBER_OF_BYTES / sizeof(uint64_t));
+  for(auto index = size_t{0}; index<contents.size();index++){
+    contents[index] = std::rand() % UINT16_MAX;
+  }
+
+  auto control_sum = uint64_t{0};
+  for(auto index = size_t{0}; index<contents.size();index++){
+    control_sum += contents[index];
+  }
+
+  for (auto _ : state) {
+ //   auto sum = uint64_t{0};
+    uint64_t summand;
+
+/*    for (auto iterator = contents.cbegin(); iterator < contents.end(); ++iterator) {
+      summand = *iterator;
+      state.PauseTiming();
+      sum += summand;
+      state.ResumeTiming();
+    }*/
+    const auto last = contents.end();
+    // auto sum = uint64_t{0};
+    for (auto first = contents.cbegin(); first != last; ++first) {
+      summand = *first;
+      (void) summand;
+      state.PauseTiming();
+      // sum = std::move(sum) + summand;
+      state.ResumeTiming();
+
+    }
+    state.PauseTiming();
+   // Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    state.ResumeTiming();
+  }
+}
+
 //arguments are file size in MB
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+// BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+// BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)->Arg(10)->Arg(100)->Arg(1000);
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <algorithm>
+#include <numeric>
 
 namespace hyrise {
 
@@ -12,24 +13,30 @@ const int32_t MB = 1000000;
 
 class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
+  uint64_t control_sum = uint64_t{0};
+  std::vector<uint32_t> numbers;
+
+
   void SetUp(::benchmark::State& state) override {
     //TODO: Make setup/teardown global per file size to improve benchmark speed
     ssize_t BUFFER_SIZE_MB = state.range(0);
 
     // each int32_t contains four bytes
-    int32_t vector_element_count = (BUFFER_SIZE_MB * MB) / 4;
-    const auto data_to_write = std::vector<int32_t>(vector_element_count, 42);
+    uint32_t vector_element_count = (BUFFER_SIZE_MB * MB) / 4;
+    numbers = std::vector<uint32_t>(vector_element_count);
+    for(size_t index = 0; index<vector_element_count; ++index){
+      numbers[index] = std::rand() % UINT32_MAX;
+    }
+    control_sum = std::accumulate(numbers.begin(), numbers.end(),uint64_t {0});
 
     int32_t fd;
     if ((fd = creat("file.txt", O_WRONLY)) < 1) {
       std::cout << "create error" << std::endl;
     }
     chmod("file.txt", S_IRWXU);  // enables owner to rwx file
-
-    if (write(fd, std::data(data_to_write), BUFFER_SIZE_MB * MB) != BUFFER_SIZE_MB * MB) {
+    if (write(fd, std::data(numbers), BUFFER_SIZE_MB * MB ) != BUFFER_SIZE_MB * MB ) {
       std::cout << "write error" << std::endl;
     }
-
     close(fd);
   }
 
@@ -51,15 +58,20 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)(benchmark::
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
-    state.ResumeTiming();
-
-    std::vector<int32_t> read_data;
-    read_data.reserve(NUMBER_OF_BYTES / 4);
+    std::vector<uint32_t> read_data;
 
     lseek(fd, 0, SEEK_SET);
+    read_data.resize(NUMBER_OF_BYTES / 4);
+    state.ResumeTiming();
+
     if (read(fd, std::data(read_data), NUMBER_OF_BYTES) != NUMBER_OF_BYTES) {
       Fail("read error: " + strerror(errno));
     }
+    state.PauseTiming();
+    auto sum = std::accumulate(read_data.begin(), read_data.end(),uint64_t {0});
+    // sum == 0 because read vector is empty
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    state.ResumeTiming();
   }
 }
 
@@ -73,36 +85,29 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)(benchmark::Sta
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
+    std::vector<uint32_t> read_data;
+    read_data.resize(NUMBER_OF_BYTES / 4);
     state.ResumeTiming();
 
-    std::vector<int32_t> read_data;
-    read_data.reserve(NUMBER_OF_BYTES / 4);
-
-    if (pread(fd, std::data(read_data), NUMBER_OF_BYTES, 0) != NUMBER_OF_BYTES) {
+    if (pread(fd, std::data(read_data), NUMBER_OF_BYTES , 0) != NUMBER_OF_BYTES) {
       Fail("read error: " + strerror(errno));
     }
+
+    state.PauseTiming();
+    auto sum = std::accumulate(read_data.begin(), read_data.end(),uint64_t {0});
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    state.ResumeTiming();
   }
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)(benchmark::State& state) {// open file
-  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
-
-  std::vector<uint64_t> contents(NUMBER_OF_BYTES / sizeof(uint64_t));
-  for(auto index = size_t{0}; index<contents.size();index++){
-    contents[index] = std::rand() % UINT16_MAX;
-  }
-
-  auto control_sum = uint64_t{0};
-  for(auto index = size_t{0}; index<contents.size();index++){
-    control_sum += contents[index];
-  }
 
   for (auto _ : state) {
     auto sum = uint64_t{0};
     uint64_t summand;
 
-    for(auto index = size_t{0}; index<contents.size();index++){
-      summand = contents[index];
+    for(auto index = size_t{0}; index< numbers.size();index++){
+      summand = numbers[index];
       state.PauseTiming();
       sum += summand;
       state.ResumeTiming();

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -16,7 +16,6 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   uint64_t control_sum = uint64_t{0};
   std::vector<uint32_t> numbers;
 
-
   void SetUp(::benchmark::State& state) override {
     //TODO: Make setup/teardown global per file size to improve benchmark speed
     ssize_t BUFFER_SIZE_MB = state.range(0);
@@ -24,17 +23,17 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
     // each int32_t contains four bytes
     uint32_t vector_element_count = (BUFFER_SIZE_MB * MB) / 4;
     numbers = std::vector<uint32_t>(vector_element_count);
-    for(size_t index = 0; index<vector_element_count; ++index){
+    for (size_t index = 0; index < vector_element_count; ++index) {
       numbers[index] = std::rand() % UINT32_MAX;
     }
-    control_sum = std::accumulate(numbers.begin(), numbers.end(),uint64_t {0});
+    control_sum = std::accumulate(numbers.begin(), numbers.end(), uint64_t{0});
 
     int32_t fd;
     if ((fd = creat("file.txt", O_WRONLY)) < 1) {
       std::cout << "create error" << std::endl;
     }
     chmod("file.txt", S_IRWXU);  // enables owner to rwx file
-    if (write(fd, std::data(numbers), BUFFER_SIZE_MB * MB ) != BUFFER_SIZE_MB * MB ) {
+    if (write(fd, std::data(numbers), BUFFER_SIZE_MB * MB) != BUFFER_SIZE_MB * MB) {
       std::cout << "write error" << std::endl;
     }
     close(fd);
@@ -48,7 +47,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  protected:
 };
 
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)(benchmark::State& state) {// open file
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)(benchmark::State& state) {  // open file
   int32_t fd;
   if ((fd = open("file.txt", O_RDONLY)) < 0) {
     std::cout << "open error " << errno << std::endl;
@@ -69,7 +68,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)(benchmark::
       Fail("read error: " + strerror(errno));
     }
     state.PauseTiming();
-    auto sum = std::accumulate(read_data.begin(), read_data.end(),uint64_t {0});
+    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     // sum == 0 because read vector is empty
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
     state.ResumeTiming();
@@ -90,19 +89,19 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)(benchmark::Sta
     read_data.resize(NUMBER_OF_BYTES / 4);
     state.ResumeTiming();
 
-    if (pread(fd, std::data(read_data), NUMBER_OF_BYTES , 0) != NUMBER_OF_BYTES) {
+    if (pread(fd, std::data(read_data), NUMBER_OF_BYTES, 0) != NUMBER_OF_BYTES) {
       Fail("read error: " + strerror(errno));
     }
 
     state.PauseTiming();
-    auto sum = std::accumulate(read_data.begin(), read_data.end(),uint64_t {0});
+    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
 
     state.ResumeTiming();
   }
 }
 
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)(benchmark::State& state) {// open file
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)(benchmark::State& state) {  // open file
 
   for (auto _ : state) {
     const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
@@ -115,7 +114,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)(benchmark::S
     read_data = numbers;
 
     state.PauseTiming();
-    auto sum = std::accumulate(read_data.begin(), read_data.end(),uint64_t {0});
+    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
 
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
     Assert(&read_data != &numbers, "Sanity check failed: Same reference");

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -1,11 +1,13 @@
-#include "micro_benchmark_basic_fixture.hpp"
-
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <algorithm>
+
 #include <numeric>
+
+#include "micro_benchmark_basic_fixture.hpp"
+
 
 namespace hyrise {
 
@@ -17,7 +19,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   std::vector<uint32_t> numbers;
 
   void SetUp(::benchmark::State& state) override {
-    //TODO: Make setup/teardown global per file size to improve benchmark speed
+    // TODO(anyone): Make setup/teardown global per file size to improve benchmark speed
     ssize_t BUFFER_SIZE_MB = state.range(0);
 
     // each int32_t contains four bytes
@@ -40,7 +42,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   }
 
   void TearDown(::benchmark::State& /*state*/) override {
-    //TODO: Error handling
+    // TODO(anyone): Error handling
     std::remove("file.txt");
   }
 
@@ -102,7 +104,6 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)(benchmark::Sta
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)(benchmark::State& state) {  // open file
-
   for (auto _ : state) {
     const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
@@ -123,7 +124,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)(benchmark::S
   }
 }
 
-//arguments are file size in MB
+// arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ)->Arg(10)->Arg(100)->Arg(1000);

--- a/src/benchmark/file_io_write_micro_benchmark.cpp
+++ b/src/benchmark/file_io_write_micro_benchmark.cpp
@@ -176,7 +176,6 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark:
   std::vector<uint64_t> copy_of_contents;
 
   for (auto _ : state) {
-    // std::memcpy(&copy_of_contents, &contents, NUMBER_OF_BYTES);
     copy_of_contents = contents;
     state.PauseTiming();
     Assert(std::equal(copy_of_contents.begin(), copy_of_contents.end(), contents.begin()), "Sanity check failed: Not the same result");
@@ -186,10 +185,10 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark:
 }
 
 //arguments are file size in MB
-//BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
-//BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
-//BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)->Arg(10)->Arg(100)->Arg(1000);
-//BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)->Arg(10)->Arg(100)->Arg(1000);
 
 

--- a/src/benchmark/file_io_write_micro_benchmark.cpp
+++ b/src/benchmark/file_io_write_micro_benchmark.cpp
@@ -166,10 +166,31 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)(ben
 	}
 }
 
+BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark::State& state) {// open file
+  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+
+  std::vector<uint64_t> contents(NUMBER_OF_BYTES / sizeof(uint64_t));
+  for(auto index = size_t{0}; index<contents.size();index++){
+    contents[index] = std::rand() % UINT16_MAX;
+  }
+  std::vector<uint64_t> copy_of_contents;
+
+  for (auto _ : state) {
+    // std::memcpy(&copy_of_contents, &contents, NUMBER_OF_BYTES);
+    copy_of_contents = contents;
+    state.PauseTiming();
+    Assert(std::equal(copy_of_contents.begin(), copy_of_contents.end(), contents.begin()), "Sanity check failed: Not the same result");
+    Assert(&copy_of_contents != &contents, "Sanity check failed: Same reference");
+    state.ResumeTiming();
+  }
+}
+
 //arguments are file size in MB
-BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)->Arg(10)->Arg(100)->Arg(1000);
+//BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+//BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
+//BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)->Arg(10)->Arg(100)->Arg(1000);
+//BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)->Arg(10)->Arg(100)->Arg(1000);
+
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_write_micro_benchmark.cpp
+++ b/src/benchmark/file_io_write_micro_benchmark.cpp
@@ -1,11 +1,13 @@
-#include "micro_benchmark_basic_fixture.hpp"
-
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <algorithm>
+
+#include "micro_benchmark_basic_fixture.hpp"
+
 
 namespace hyrise {
 
@@ -14,7 +16,7 @@ const int32_t MB = 1000000;
 class FileIOWriteMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
   void SetUp(::benchmark::State& state) override {
-    //TODO: Make setup/teardown global per file size to improve benchmark speed
+    // TODO(anyone): Make setup/teardown global per file size to improve benchmark speed
     ssize_t BUFFER_SIZE_MB = state.range(0);
     // each int32_t contains four bytes
     int32_t vector_element_count = (BUFFER_SIZE_MB * MB) / 4;
@@ -27,7 +29,7 @@ class FileIOWriteMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
   }
 
   void TearDown(::benchmark::State& /*state*/) override {
-    //TODO: Error handling
+    // TODO(anyone): Error handling
     std::remove("file.txt");
   }
 
@@ -184,7 +186,7 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark:
   }
 }
 
-//arguments are file size in MB
+// arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)->Arg(10)->Arg(100)->Arg(1000);

--- a/src/benchmark/file_io_write_micro_benchmark.cpp
+++ b/src/benchmark/file_io_write_micro_benchmark.cpp
@@ -1,12 +1,11 @@
 #include "micro_benchmark_basic_fixture.hpp"
 
 #include <fcntl.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/mman.h>
 #include <unistd.h>
 #include <algorithm>
-
 
 namespace hyrise {
 
@@ -15,9 +14,9 @@ const int32_t MB = 1000000;
 class FileIOWriteMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
   void SetUp(::benchmark::State& state) override {
-		//TODO: Make setup/teardown global per file size to improve benchmark speed
+    //TODO: Make setup/teardown global per file size to improve benchmark speed
     ssize_t BUFFER_SIZE_MB = state.range(0);
-		// each int32_t contains four bytes
+    // each int32_t contains four bytes
     int32_t vector_element_count = (BUFFER_SIZE_MB * MB) / 4;
     data_to_write = std::vector<int32_t>(vector_element_count, 42);
 
@@ -36,12 +35,12 @@ class FileIOWriteMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
   std::vector<int32_t> data_to_write;
 };
 
-BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)(benchmark::State& state) {// open file
+BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)(benchmark::State& state) {  // open file
   int32_t fd;
   if ((fd = open("file.txt", O_WRONLY)) < 0) {
-		std::cout << "open error " << errno << std::endl;
+    std::cout << "open error " << errno << std::endl;
   }
-	const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -49,128 +48,128 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)(benchmark
     state.ResumeTiming();
 
     if (write(fd, std::data(data_to_write), NUMBER_OF_BYTES) != NUMBER_OF_BYTES) {
-			std::cout << "write error " << errno << std::endl;
-		}
+      std::cout << "write error " << errno << std::endl;
+    }
   }
 }
 
 BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)(benchmark::State& state) {
   int32_t fd;
-	if ((fd = open("file.txt", O_WRONLY)) < 0) {
-		std::cout << "open error " << errno << std::endl;
-	}
-	const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+  if ((fd = open("file.txt", O_WRONLY)) < 0) {
+    std::cout << "open error " << errno << std::endl;
+  }
+  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
-	for (auto _ : state) {
-		state.PauseTiming();
-		micro_benchmark_clear_disk_cache();
-		state.ResumeTiming();
+  for (auto _ : state) {
+    state.PauseTiming();
+    micro_benchmark_clear_disk_cache();
+    state.ResumeTiming();
 
-		if (pwrite(fd, std::data(data_to_write), NUMBER_OF_BYTES, 0) != NUMBER_OF_BYTES) {
-			std::cout << "write error " << errno << std::endl;
-		}
-	}
+    if (pwrite(fd, std::data(data_to_write), NUMBER_OF_BYTES, 0) != NUMBER_OF_BYTES) {
+      std::cout << "write error " << errno << std::endl;
+    }
+  }
 }
 
 BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)(benchmark::State& state) {
-	const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
-	int32_t fd;
-	if ((fd = open("file.txt", O_RDWR | O_CREAT | O_TRUNC)) < 0) {
-		std::cout << "open error " << errno << std::endl;
-	}
+  int32_t fd;
+  if ((fd = open("file.txt", O_RDWR | O_CREAT | O_TRUNC)) < 0) {
+    std::cout << "open error " << errno << std::endl;
+  }
 
-	// set output file size
-	if (ftruncate(fd, NUMBER_OF_BYTES) < 0)	{
-		std::cout << "ftruncate error " << errno << std::endl;
-	}
+  // set output file size
+  if (ftruncate(fd, NUMBER_OF_BYTES) < 0) {
+    std::cout << "ftruncate error " << errno << std::endl;
+  }
 
-	for (auto _ : state) {
-		state.PauseTiming();
-		micro_benchmark_clear_disk_cache();
-		state.ResumeTiming();
+  for (auto _ : state) {
+    state.PauseTiming();
+    micro_benchmark_clear_disk_cache();
+    state.ResumeTiming();
 
     // Getting the mapping to memory.
     off_t OFFSET = 0;
-		/*
+    /*
     mmap man page: 
     MAP_PRIVATE:
       "Updates to the mapping are not visible to other processes 
       mapping the same file"
       "changes are not carried through to the underlying files"
-    */ 
+    */
     auto map = mmap(NULL, NUMBER_OF_BYTES, PROT_WRITE, MAP_PRIVATE, fd, OFFSET);
     if (map == MAP_FAILED) {
       std::cout << "Mapping Failed. " << std::strerror(errno) << std::endl;
       continue;
     }
-    
+
     // Due to mmap, only writing in memory is required.
     memset(map, *(std::data(data_to_write)), NUMBER_OF_BYTES);
     // After writing, sync changes to filesystem.
-		if (msync(map, NUMBER_OF_BYTES, MS_SYNC) == -1) {
-			std::cout << "Write error " << errno << std::endl;
-		}
+    if (msync(map, NUMBER_OF_BYTES, MS_SYNC) == -1) {
+      std::cout << "Write error " << errno << std::endl;
+    }
 
     // Remove memory mapping after job is done.
     if (munmap(map, NUMBER_OF_BYTES) != 0) {
       std::cout << "Unmapping failed." << std::endl;
     }
-	}
+  }
 }
 
 BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)(benchmark::State& state) {
-	const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
-	int32_t fd;
-	if ((fd = open("file.txt", O_RDWR | O_CREAT | O_TRUNC)) < 0) {
-		std::cout << "open error " << errno << std::endl;
-	}
+  int32_t fd;
+  if ((fd = open("file.txt", O_RDWR | O_CREAT | O_TRUNC)) < 0) {
+    std::cout << "open error " << errno << std::endl;
+  }
 
-	// set output file size
-	if (ftruncate(fd, NUMBER_OF_BYTES) < 0)	{
-		std::cout << "ftruncate error " << errno << std::endl;
-	}
+  // set output file size
+  if (ftruncate(fd, NUMBER_OF_BYTES) < 0) {
+    std::cout << "ftruncate error " << errno << std::endl;
+  }
 
-	for (auto _ : state) {
-		state.PauseTiming();
-		micro_benchmark_clear_disk_cache();
-		state.ResumeTiming();
+  for (auto _ : state) {
+    state.PauseTiming();
+    micro_benchmark_clear_disk_cache();
+    state.ResumeTiming();
 
     // Getting the mapping to memory.
     off_t OFFSET = 0;
-		/*
+    /*
     mmap man page: 
     MAP_SHARED:
       "Updates to the mapping are visible to other processes mapping 
       the same region"
       "changes are carried through to the underlying files"
-    */ 
+    */
     auto map = mmap(NULL, NUMBER_OF_BYTES, PROT_WRITE, MAP_SHARED, fd, OFFSET);
     if (map == MAP_FAILED) {
       std::cout << "Mapping Failed. " << std::strerror(errno) << std::endl;
       continue;
     }
-    
+
     // Due to mmap, only writing in memory is required.
     memset(map, *(std::data(data_to_write)), NUMBER_OF_BYTES);
     // After writing, sync changes to filesystem.
-		if (msync(map, NUMBER_OF_BYTES, MS_SYNC) == -1) {
-			std::cout << "Write error " << errno << std::endl;
-		}
+    if (msync(map, NUMBER_OF_BYTES, MS_SYNC) == -1) {
+      std::cout << "Write error " << errno << std::endl;
+    }
 
     // Remove memory mapping after job is done.
     if (munmap(map, NUMBER_OF_BYTES) != 0) {
       std::cout << "Unmapping failed." << std::endl;
     }
-	}
+  }
 }
 
-BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark::State& state) {// open file
+BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark::State& state) {  // open file
   const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
   std::vector<uint64_t> contents(NUMBER_OF_BYTES / sizeof(uint64_t));
-  for(auto index = size_t{0}; index<contents.size();index++){
+  for (auto index = size_t{0}; index < contents.size(); index++) {
     contents[index] = std::rand() % UINT16_MAX;
   }
   std::vector<uint64_t> copy_of_contents;
@@ -178,7 +177,8 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark:
   for (auto _ : state) {
     copy_of_contents = contents;
     state.PauseTiming();
-    Assert(std::equal(copy_of_contents.begin(), copy_of_contents.end(), contents.begin()), "Sanity check failed: Not the same result");
+    Assert(std::equal(copy_of_contents.begin(), copy_of_contents.end(), contents.begin()),
+           "Sanity check failed: Not the same result");
     Assert(&copy_of_contents != &contents, "Sanity check failed: Same reference");
     state.ResumeTiming();
   }
@@ -190,6 +190,5 @@ BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)->Arg(10)->
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)->Arg(10)->Arg(100)->Arg(1000);
-
 
 }  // namespace hyrise

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -15,7 +15,7 @@ void micro_benchmark_clear_cache() {
 }
 
 void micro_benchmark_clear_disk_cache() {
-  //TODO: better documentation of which caches we are clearing
+  // TODO(anyone): better documentation of which caches we are clearing
   sync();
   std::ofstream ofs("/proc/sys/vm/drop_caches");
   ofs << "3" << std::endl;

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -1,8 +1,8 @@
 #include "micro_benchmark_utils.hpp"
 
 #include <stddef.h>
-#include <fstream>
 #include <unistd.h>
+#include <fstream>
 
 namespace hyrise {
 
@@ -15,10 +15,10 @@ void micro_benchmark_clear_cache() {
 }
 
 void micro_benchmark_clear_disk_cache() {
-	//TODO: better documentation of which caches we are clearing
-	sync();
-	std::ofstream ofs("/proc/sys/vm/drop_caches");
-	ofs << "3" << std::endl;
+  //TODO: better documentation of which caches we are clearing
+  sync();
+  std::ofstream ofs("/proc/sys/vm/drop_caches");
+  ofs << "3" << std::endl;
 }
 
 }  // namespace hyrise

--- a/src/benchmark/micro_benchmark_utils.hpp
+++ b/src/benchmark/micro_benchmark_utils.hpp
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-
 namespace hyrise {
 
 void micro_benchmark_clear_cache();


### PR DESCRIPTION
This PR
- introduces in memory read and write benchmarks
- adds sanity checks to read and pread benchmark

The sanity check is currently to simply add up all read numbers and compare them to a sum that was calculated beforehand.
The in memory benchmarks simply read and write contents from a vector. The are quite similar as reading from a vector mainly also means to write these values somewhere.
