### PR TITLE
[mmap] Random Data Write Access Benchmark

### DIFF
--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -41,7 +41,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  protected:
 };
 
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)(benchmark::State& state) {// open file
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC)(benchmark::State& state) {  // open file
   int32_t fd;
   if ((fd = open("file.txt", O_RDONLY)) < 0) {
     std::cout << "open error " << errno << std::endl;

--- a/src/benchmark/file_io_write_micro_benchmark.cpp
+++ b/src/benchmark/file_io_write_micro_benchmark.cpp
@@ -1,11 +1,12 @@
-#include "micro_benchmark_basic_fixture.hpp"
-
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <algorithm>
+
+#include "micro_benchmark_basic_fixture.hpp"
 
 namespace hyrise {
 
@@ -14,7 +15,7 @@ const int32_t MB = 1000000;
 class FileIOWriteMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
   void SetUp(::benchmark::State& state) override {
-    //TODO: Make setup/teardown global per file size to improve benchmark speed
+    // TODO(phoeinx): Make setup/teardown global per file size to improve benchmark speed
     ssize_t BUFFER_SIZE_MB = state.range(0);
     // each int32_t contains four bytes
     int32_t vector_element_count = (BUFFER_SIZE_MB * MB) / 4;
@@ -27,7 +28,7 @@ class FileIOWriteMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
   }
 
   void TearDown(::benchmark::State& /*state*/) override {
-    //TODO: Error handling
+    // TODO(phoeinx): Error handling
     std::remove("file.txt");
   }
 
@@ -124,7 +125,7 @@ void FileIOWriteMicroBenchmarkFixture::mmap_write_benchmark(benchmark::State& st
       the same region"
       "changes are carried through to the underlying files"
     */
-    auto map = (char*)mmap(NULL, NUMBER_OF_BYTES, PROT_WRITE, flag, fd, OFFSET);
+    auto map = reinterpret_cast<char*>(mmap(NULL, NUMBER_OF_BYTES, PROT_WRITE, flag, fd, OFFSET));
     if (map == MAP_FAILED) {
       std::cout << "Mapping Failed. " << std::strerror(errno) << std::endl;
       continue;
@@ -139,7 +140,7 @@ void FileIOWriteMicroBenchmarkFixture::mmap_write_benchmark(benchmark::State& st
         // Generating random indexes should not play a role in the benchmark.
         std::vector<int> ind_access_order = generate_random_indexes(NUMBER_OF_BYTES);
         state.ResumeTiming();
-        for (unsigned long int idx = 0; idx < ind_access_order.size(); ++idx) {
+        for (uint32_t idx = 0; idx < ind_access_order.size(); ++idx) {
           map[idx] = 42;
         }
         break;
@@ -157,7 +158,7 @@ void FileIOWriteMicroBenchmarkFixture::mmap_write_benchmark(benchmark::State& st
   }
 }
 
-//arguments are file size in MB
+// Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)->Arg(10)->Arg(100)->Arg(1000);

--- a/src/benchmark/file_io_write_micro_benchmark.cpp
+++ b/src/benchmark/file_io_write_micro_benchmark.cpp
@@ -1,12 +1,11 @@
 #include "micro_benchmark_basic_fixture.hpp"
 
 #include <fcntl.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/mman.h>
 #include <unistd.h>
 #include <algorithm>
-
 
 namespace hyrise {
 
@@ -15,9 +14,9 @@ const int32_t MB = 1000000;
 class FileIOWriteMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
   void SetUp(::benchmark::State& state) override {
-		//TODO: Make setup/teardown global per file size to improve benchmark speed
+    //TODO: Make setup/teardown global per file size to improve benchmark speed
     ssize_t BUFFER_SIZE_MB = state.range(0);
-		// each int32_t contains four bytes
+    // each int32_t contains four bytes
     int32_t vector_element_count = (BUFFER_SIZE_MB * MB) / 4;
     data_to_write = std::vector<int32_t>(vector_element_count, 42);
 
@@ -34,14 +33,15 @@ class FileIOWriteMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
 
  protected:
   std::vector<int32_t> data_to_write;
+  void mmap_write_benchmark(benchmark::State& state, const int flag, int data_access_mode, const int32_t file_size);
 };
 
-BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)(benchmark::State& state) {// open file
+BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)(benchmark::State& state) {  // open file
   int32_t fd;
   if ((fd = open("file.txt", O_WRONLY)) < 0) {
-		std::cout << "open error " << errno << std::endl;
+    std::cout << "open error " << errno << std::endl;
   }
-	const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -49,127 +49,119 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)(benchmark
     state.ResumeTiming();
 
     if (write(fd, std::data(data_to_write), NUMBER_OF_BYTES) != NUMBER_OF_BYTES) {
-			std::cout << "write error " << errno << std::endl;
-		}
+      std::cout << "write error " << errno << std::endl;
+    }
   }
 }
 
 BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)(benchmark::State& state) {
   int32_t fd;
-	if ((fd = open("file.txt", O_WRONLY)) < 0) {
-		std::cout << "open error " << errno << std::endl;
-	}
-	const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+  if ((fd = open("file.txt", O_WRONLY)) < 0) {
+    std::cout << "open error " << errno << std::endl;
+  }
+  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
-	for (auto _ : state) {
-		state.PauseTiming();
-		micro_benchmark_clear_disk_cache();
-		state.ResumeTiming();
+  for (auto _ : state) {
+    state.PauseTiming();
+    micro_benchmark_clear_disk_cache();
+    state.ResumeTiming();
 
-		if (pwrite(fd, std::data(data_to_write), NUMBER_OF_BYTES, 0) != NUMBER_OF_BYTES) {
-			std::cout << "write error " << errno << std::endl;
-		}
-	}
+    if (pwrite(fd, std::data(data_to_write), NUMBER_OF_BYTES, 0) != NUMBER_OF_BYTES) {
+      std::cout << "write error " << errno << std::endl;
+    }
+  }
 }
 
 BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)(benchmark::State& state) {
-	const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
-
-	int32_t fd;
-	if ((fd = open("file.txt", O_RDWR | O_CREAT | O_TRUNC)) < 0) {
-		std::cout << "open error " << errno << std::endl;
-	}
-
-	// set output file size
-	if (ftruncate(fd, NUMBER_OF_BYTES) < 0)	{
-		std::cout << "ftruncate error " << errno << std::endl;
-	}
-
-	for (auto _ : state) {
-		state.PauseTiming();
-		micro_benchmark_clear_disk_cache();
-		state.ResumeTiming();
-
-    // Getting the mapping to memory.
-    off_t OFFSET = 0;
-		/*
-    mmap man page: 
-    MAP_PRIVATE:
-      "Updates to the mapping are not visible to other processes 
-      mapping the same file"
-      "changes are not carried through to the underlying files"
-    */ 
-    auto map = mmap(NULL, NUMBER_OF_BYTES, PROT_WRITE, MAP_PRIVATE, fd, OFFSET);
-    if (map == MAP_FAILED) {
-      std::cout << "Mapping Failed. " << std::strerror(errno) << std::endl;
-      continue;
-    }
-    
-    // Due to mmap, only writing in memory is required.
-    memset(map, *(std::data(data_to_write)), NUMBER_OF_BYTES);
-    // After writing, sync changes to filesystem.
-		if (msync(map, NUMBER_OF_BYTES, MS_SYNC) == -1) {
-			std::cout << "Write error " << errno << std::endl;
-		}
-
-    // Remove memory mapping after job is done.
-    if (munmap(map, NUMBER_OF_BYTES) != 0) {
-      std::cout << "Unmapping failed." << std::endl;
-    }
-	}
+  mmap_write_benchmark(state, MAP_PRIVATE, 0, state.range(0));
 }
 
-BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)(benchmark::State& state) {
-	const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)(benchmark::State& state) {
+  mmap_write_benchmark(state, MAP_SHARED, 0, state.range(0));
+}
 
-	int32_t fd;
-	if ((fd = open("file.txt", O_RDWR | O_CREAT | O_TRUNC)) < 0) {
-		std::cout << "open error " << errno << std::endl;
-	}
+BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)(benchmark::State& state) {
+  mmap_write_benchmark(state, MAP_SHARED, 1, state.range(0));
+}
 
-	// set output file size
-	if (ftruncate(fd, NUMBER_OF_BYTES) < 0)	{
-		std::cout << "ftruncate error " << errno << std::endl;
-	}
+/**
+ * Performs a benchmark run with the given parameters. 
+ * 
+ * @arguments:
+ *      state: the benchmark::State object handed to the called benchmarking function.
+ *      flag: The mmap flag (e.g., MAP_PRIVATE or MAP_SHARED).
+ *      data_access_mode: The way the data is written.
+ *                  (-1)  No data access
+ *                  (0)   Sequential
+ *                  (1)   Random
+ *      file_size: Size argument of benchmark.
+*/
+void FileIOWriteMicroBenchmarkFixture::mmap_write_benchmark(benchmark::State& state, const int flag,
+                                                            int data_access_mode, const int32_t file_size) {
+  const int32_t NUMBER_OF_BYTES = file_size * MB;
 
-	for (auto _ : state) {
-		state.PauseTiming();
-		micro_benchmark_clear_disk_cache();
-		state.ResumeTiming();
+  int32_t fd;
+  if ((fd = open("file.txt", O_RDWR | O_CREAT | O_TRUNC)) < 0) {
+    std::cout << "open error " << errno << std::endl;
+  }
+
+  // set output file size
+  if (ftruncate(fd, NUMBER_OF_BYTES) < 0) {
+    std::cout << "ftruncate error " << errno << std::endl;
+  }
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    micro_benchmark_clear_disk_cache();
+    state.ResumeTiming();
 
     // Getting the mapping to memory.
     off_t OFFSET = 0;
-		/*
+    /*
     mmap man page: 
     MAP_SHARED:
       "Updates to the mapping are visible to other processes mapping 
       the same region"
       "changes are carried through to the underlying files"
-    */ 
-    auto map = mmap(NULL, NUMBER_OF_BYTES, PROT_WRITE, MAP_SHARED, fd, OFFSET);
+    */
+    auto map = (char*)mmap(NULL, NUMBER_OF_BYTES, PROT_WRITE, flag, fd, OFFSET);
     if (map == MAP_FAILED) {
       std::cout << "Mapping Failed. " << std::strerror(errno) << std::endl;
       continue;
     }
-    
-    // Due to mmap, only writing in memory is required.
-    memset(map, *(std::data(data_to_write)), NUMBER_OF_BYTES);
+
+    switch (data_access_mode) {
+      case 0:
+        memcpy(map, std::data(data_to_write), NUMBER_OF_BYTES);
+        break;
+      case 1:
+        state.PauseTiming();
+        // Generating random indexes should not play a role in the benchmark.
+        std::vector<int> ind_access_order = generate_random_indexes(NUMBER_OF_BYTES);
+        state.ResumeTiming();
+        for (unsigned long int idx = 0; idx < ind_access_order.size(); ++idx) {
+          map[idx] = 42;
+        }
+        break;
+    }
+
     // After writing, sync changes to filesystem.
-		if (msync(map, NUMBER_OF_BYTES, MS_SYNC) == -1) {
-			std::cout << "Write error " << errno << std::endl;
-		}
+    if (msync(map, NUMBER_OF_BYTES, MS_SYNC) == -1) {
+      std::cout << "Write error " << errno << std::endl;
+    }
 
     // Remove memory mapping after job is done.
     if (munmap(map, NUMBER_OF_BYTES) != 0) {
       std::cout << "Unmapping failed." << std::endl;
     }
-	}
+  }
 }
 
 //arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC)->Arg(10)->Arg(100)->Arg(1000);
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
 }  // namespace hyrise

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -1,8 +1,11 @@
 #include "micro_benchmark_utils.hpp"
 
 #include <stddef.h>
-#include <fstream>
 #include <unistd.h>
+#include <fstream>
+
+#include <algorithm>
+#include <random>
 
 namespace hyrise {
 
@@ -15,10 +18,22 @@ void micro_benchmark_clear_cache() {
 }
 
 void micro_benchmark_clear_disk_cache() {
-	//TODO: better documentation of which caches we are clearing
-	sync();
-	std::ofstream ofs("/proc/sys/vm/drop_caches");
-	ofs << "3" << std::endl;
+  //TODO: better documentation of which caches we are clearing
+  sync();
+  std::ofstream ofs("/proc/sys/vm/drop_caches");
+  ofs << "3" << std::endl;
+}
+
+/**
+ * Generates random indexes between 0 and number.
+*/
+std::vector<int> generate_random_indexes(int number) {
+  std::vector<int> sequence(number);
+  std::iota(std::begin(sequence), std::end(sequence), 0);
+  auto rng = std::default_random_engine{};
+  std::shuffle(std::begin(sequence), std::end(sequence), rng);
+
+  return sequence;
 }
 
 }  // namespace hyrise

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -18,7 +18,7 @@ void micro_benchmark_clear_cache() {
 }
 
 void micro_benchmark_clear_disk_cache() {
-  //TODO: better documentation of which caches we are clearing
+  // TODO(phoenix): better documentation of which caches we are clearing
   sync();
   std::ofstream ofs("/proc/sys/vm/drop_caches");
   ofs << "3" << std::endl;

--- a/src/benchmark/micro_benchmark_utils.hpp
+++ b/src/benchmark/micro_benchmark_utils.hpp
@@ -2,10 +2,10 @@
 
 #include <vector>
 
-
 namespace hyrise {
 
 void micro_benchmark_clear_cache();
 void micro_benchmark_clear_disk_cache();
+std::vector<int> generate_random_indexes(int number);
 
 }  // namespace hyrise


### PR DESCRIPTION
Adds the following things: 
1. Adds a mmap benchmark, which performs random write accesses to data within the file. 
2. Formats stuff.
3. Streamlines mmap implementation to have less LOC.