### PR TITLE
Random read benchmarks

### DIFF
--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -65,13 +65,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)(
 
   for (auto _ : state) {
     state.PauseTiming();
+
     micro_benchmark_clear_disk_cache();
     std::vector<uint32_t> read_data;
-
     auto read_data_size = NUMBER_OF_BYTES / 4;
     read_data.resize(read_data_size);
-    state.ResumeTiming();
 
+    state.ResumeTiming();
     for(auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index){
       lseek(fd, sizeof (uint32_t) * index, SEEK_SET);
 
@@ -79,11 +79,11 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)(
         Fail("read error: " + strerror(errno));
       }
     }
-
     state.PauseTiming();
+
     auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    // sum == 0 because read vector is empty
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
+
     state.ResumeTiming();
   }
 }
@@ -97,27 +97,27 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)(benc
 
   for (auto _ : state) {
     state.PauseTiming();
+
     micro_benchmark_clear_disk_cache();
     std::vector<uint32_t> read_data;
     auto read_data_size = NUMBER_OF_BYTES / 4;
     read_data.resize(read_data_size);
+
     state.ResumeTiming();
 
     lseek(fd, 0, SEEK_SET);
-
     for(auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index){
-      // here
       lseek(fd, sizeof (uint32_t) * random_indices[index], SEEK_SET);
 
       if (read(fd, std::data(read_data) + index, sizeof (uint32_t)) != sizeof (uint32_t)) {
         Fail("read error: " + strerror(errno));
       }
     }
-
     state.PauseTiming();
+
     auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    // sum == 0 because read vector is empty
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
+
     state.ResumeTiming();
   }
 }
@@ -131,10 +131,12 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)(ben
 
   for (auto _ : state) {
     state.PauseTiming();
+
     micro_benchmark_clear_disk_cache();
     std::vector<uint32_t> read_data;
     auto read_data_size = NUMBER_OF_BYTES / 4;
     read_data.resize(read_data_size);
+
     state.ResumeTiming();
 
     for(auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index){
@@ -142,12 +144,8 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)(ben
         Fail("read error: " + strerror(errno));
       }
     }
-
-    if (pread(fd, std::data(read_data), NUMBER_OF_BYTES, 0) != NUMBER_OF_BYTES) {
-      Fail("read error: " + strerror(errno));
-    }
-
     state.PauseTiming();
+
     auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
 
@@ -177,14 +175,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchma
       }
     }
     state.PauseTiming();
+
     auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
 
     state.ResumeTiming();
   }
 }
-
-
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(benchmark::State& state) {  // open file
   for (auto _ : state) {

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -265,13 +265,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)->Arg(10);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)->Arg(10);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)->Arg(10);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -3,9 +3,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <algorithm>
+#include <iterator>
 #include <numeric>
 #include <random>
-#include <iterator>
 #include "micro_benchmark_basic_fixture.hpp"
 
 namespace hyrise {
@@ -72,10 +72,10 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)(
     read_data.resize(read_data_size);
 
     state.ResumeTiming();
-    for(auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index){
-      lseek(fd, sizeof (uint32_t) * index, SEEK_SET);
+    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
+      lseek(fd, sizeof(uint32_t) * index, SEEK_SET);
 
-      if (read(fd, std::data(read_data) + index, sizeof (uint32_t)) != sizeof (uint32_t)) {
+      if (read(fd, std::data(read_data) + index, sizeof(uint32_t)) != sizeof(uint32_t)) {
         Fail("read error: " + strerror(errno));
       }
     }
@@ -106,10 +106,10 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)(benc
     state.ResumeTiming();
 
     lseek(fd, 0, SEEK_SET);
-    for(auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index){
-      lseek(fd, sizeof (uint32_t) * random_indices[index], SEEK_SET);
+    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
+      lseek(fd, sizeof(uint32_t) * random_indices[index], SEEK_SET);
 
-      if (read(fd, std::data(read_data) + index, sizeof (uint32_t)) != sizeof (uint32_t)) {
+      if (read(fd, std::data(read_data) + index, sizeof(uint32_t)) != sizeof(uint32_t)) {
         Fail("read error: " + strerror(errno));
       }
     }
@@ -139,8 +139,8 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)(ben
 
     state.ResumeTiming();
 
-    for(auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index){
-      if (pread(fd, std::data(read_data) + index, sizeof (uint32_t), sizeof (uint32_t) * index) != sizeof (uint32_t)) {
+    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
+      if (pread(fd, std::data(read_data) + index, sizeof(uint32_t), sizeof(uint32_t) * index) != sizeof(uint32_t)) {
         Fail("read error: " + strerror(errno));
       }
     }
@@ -160,7 +160,6 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchma
   }
   const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
 
-
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
@@ -169,8 +168,9 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchma
     read_data.resize(read_data_size);
     state.ResumeTiming();
 
-    for(auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index){
-      if (pread(fd, std::data(read_data) + index, sizeof (uint32_t), sizeof (uint32_t) * random_indices[index]) != sizeof (uint32_t)) {
+    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
+      if (pread(fd, std::data(read_data) + index, sizeof(uint32_t), sizeof(uint32_t) * random_indices[index]) !=
+          sizeof(uint32_t)) {
         Fail("read error: " + strerror(errno));
       }
     }
@@ -193,7 +193,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(b
     read_data.resize(read_data_size);
     state.ResumeTiming();
 
-    for(auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index){
+    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
       read_data[index] = numbers[index];
     }
 
@@ -217,7 +217,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
     read_data.resize(random_read_amount);
     state.ResumeTiming();
 
-    for(auto index = size_t{0}; index < random_read_amount; ++index){
+    for (auto index = size_t{0}; index < random_read_amount; ++index) {
       read_data[index] = numbers[random_indices[index]];
     }
 
@@ -232,14 +232,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)->Arg(10);//->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)->Arg(10);//->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)->Arg(10);//->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10);//->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10);//->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10);//->Arg(100)->Arg(1000);
-
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -10,7 +10,7 @@
 
 namespace hyrise {
 
-const int32_t MB = 1000000;
+const auto MB = uint32_t{1'000'000};
 
 class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
@@ -66,15 +66,16 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)(
   }
 
   const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
-  const auto read_data_size = NUMBER_OF_BYTES / 4;
-  const auto max_read_data_size = static_cast<size_t>(read_data_size);
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto read_data_size = NUMBER_OF_BYTES / uint32_t_size;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
+
 
   for (auto _ : state) {
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
-    std::vector<uint32_t> read_data;
+    auto read_data = std::vector<uint32_t>{};
     read_data.resize(read_data_size);
 
     state.ResumeTiming();
@@ -84,7 +85,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)(
       if (read(fd, std::data(read_data) + index, uint32_t_size) != uint32_t_size) {
         Fail("read error: " + strerror(errno));
       }
-      // Assert(read(fd, read_data_start + index, uint32_t_size) != uint32_t_size, "read error: " + strerror(errno));
+      //Assert(read(fd, read_data_start + index, uint32_t_size) != uint32_t_size, "read error: " + strerror(errno));
     }
     state.PauseTiming();
 
@@ -102,15 +103,15 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)(benc
   }
 
   const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
-  const auto read_data_size = NUMBER_OF_BYTES / 4;
-  const auto max_read_data_size = static_cast<size_t>(read_data_size);
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto read_data_size = NUMBER_OF_BYTES / uint32_t_size;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
 
   for (auto _ : state) {
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
-    std::vector<uint32_t> read_data;
+    auto read_data = std::vector<uint32_t>{};
     read_data.resize(read_data_size);
     auto* read_data_start = std::data(read_data);
 
@@ -122,7 +123,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)(benc
       if (read(fd, read_data_start + index, uint32_t_size) != uint32_t_size) {
         Fail("read error: " + strerror(errno));
       }
-      // Assert(read(fd, read_data_start + index, uint32_t_size) != uint32_t_size, "read error: " + strerror(errno));
+      //Assert(read(fd, read_data_start + index, uint32_t_size) != uint32_t_size, "read error: " + strerror(errno));
     }
     state.PauseTiming();
 
@@ -140,15 +141,15 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)(ben
   }
 
   const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
-  const auto read_data_size = NUMBER_OF_BYTES / 4;
-  const auto max_read_data_size = static_cast<size_t>(read_data_size);
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto read_data_size = NUMBER_OF_BYTES / uint32_t_size;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
 
   for (auto _ : state) {
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
-    std::vector<uint32_t> read_data;
+    auto read_data = std::vector<uint32_t>{};
     read_data.resize(read_data_size);
     auto* read_data_start = std::data(read_data);
 
@@ -158,9 +159,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)(ben
       if (pread(fd, read_data_start + index, uint32_t_size, uint32_t_size * index) != uint32_t_size) {
         Fail("read error: " + strerror(errno));
       }
-      // TODO Find out why permission error
-      // Assert(pread(fd, read_data_start + index, uint32_t_size, uint32_t_size * index) != uint32_t_size,
-      //       "read error: " + strerror(errno));
+      //Assert(pread(fd, read_data_start + index, uint32_t_size, uint32_t_size * index) != uint32_t_size, "read error: " + strerror(errno));
     }
     state.PauseTiming();
 
@@ -178,14 +177,15 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchma
   }
 
   const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
-  const auto read_data_size = NUMBER_OF_BYTES / 4;
-  const auto max_read_data_size = static_cast<size_t>(read_data_size);
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto read_data_size = NUMBER_OF_BYTES / uint32_t_size;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
+
 
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
-    std::vector<uint32_t> read_data;
+    auto read_data = std::vector<uint32_t>{};
     read_data.resize(read_data_size);
     auto* read_data_start = std::data(read_data);
 
@@ -207,12 +207,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchma
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(benchmark::State& state) {  // open file
   const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
-  const auto read_data_size = NUMBER_OF_BYTES / 4;
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto read_data_size = NUMBER_OF_BYTES / uint32_t_size;
   const auto max_read_data_size = static_cast<size_t>(read_data_size);
 
   for (auto _ : state) {
     state.PauseTiming();
-    std::vector<uint32_t> read_data;
+    auto read_data = std::vector<uint32_t>{};
     read_data.resize(read_data_size);
 
     state.ResumeTiming();
@@ -233,11 +234,12 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(b
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(benchmark::State& state) {  // open file
   const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
-  const auto random_read_amount = static_cast<size_t>(NUMBER_OF_BYTES / 4);
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto random_read_amount = static_cast<size_t>(NUMBER_OF_BYTES / uint32_t_size);
 
   for (auto _ : state) {
     state.PauseTiming();
-    std::vector<uint32_t> read_data;
+    auto read_data = std::vector<uint32_t>{};
     read_data.resize(random_read_amount);
     state.ResumeTiming();
 

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -33,18 +33,21 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
 
     random_indices = std::vector<uint32_t>(vector_element_count);
     std::iota(std::begin(random_indices), std::end(random_indices), 0);
-    std::random_device rd;
-    std::mt19937 engine(rd());
+    auto rd = std::random_device{};
+    auto engine = std::mt19937{rd()};
     std::shuffle(random_indices.begin(), random_indices.end(), engine);
 
     int32_t fd;
     if ((fd = creat("file.txt", O_WRONLY)) < 1) {
       std::cout << "create error" << std::endl;
     }
+    //Assert((fd = creat("file.txt", O_WRONLY)) < 1, "create error");
     chmod("file.txt", S_IRWXU);  // enables owner to rwx file
+    //Assert(write(fd, std::data(numbers), BUFFER_SIZE_MB * MB != BUFFER_SIZE_MB * MB), "write error");
     if (write(fd, std::data(numbers), BUFFER_SIZE_MB * MB) != BUFFER_SIZE_MB * MB) {
       std::cout << "write error" << std::endl;
     }
+
     close(fd);
   }
 
@@ -61,27 +64,31 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)(
   if ((fd = open("file.txt", O_RDONLY)) < 0) {
     std::cout << "open error " << errno << std::endl;
   }
-  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+
+  const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
+  const auto read_data_size = NUMBER_OF_BYTES / 4;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
 
   for (auto _ : state) {
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
     std::vector<uint32_t> read_data;
-    auto read_data_size = NUMBER_OF_BYTES / 4;
     read_data.resize(read_data_size);
 
     state.ResumeTiming();
-    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
-      lseek(fd, sizeof(uint32_t) * index, SEEK_SET);
 
-      if (read(fd, std::data(read_data) + index, sizeof(uint32_t)) != sizeof(uint32_t)) {
+    for (auto index = size_t{0}; index < max_read_data_size; ++index) {
+      lseek(fd, uint32_t_size * index, SEEK_SET);
+      if (read(fd, std::data(read_data) + index, uint32_t_size) != uint32_t_size) {
         Fail("read error: " + strerror(errno));
       }
+      // Assert(read(fd, read_data_start + index, uint32_t_size) != uint32_t_size, "read error: " + strerror(errno));
     }
     state.PauseTiming();
 
-    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
 
     state.ResumeTiming();
@@ -93,29 +100,33 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)(benc
   if ((fd = open("file.txt", O_RDONLY)) < 0) {
     std::cout << "open error " << errno << std::endl;
   }
-  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+
+  const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
+  const auto read_data_size = NUMBER_OF_BYTES / 4;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
 
   for (auto _ : state) {
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
     std::vector<uint32_t> read_data;
-    auto read_data_size = NUMBER_OF_BYTES / 4;
     read_data.resize(read_data_size);
+    auto* read_data_start = std::data(read_data);
 
     state.ResumeTiming();
 
     lseek(fd, 0, SEEK_SET);
-    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
-      lseek(fd, sizeof(uint32_t) * random_indices[index], SEEK_SET);
-
-      if (read(fd, std::data(read_data) + index, sizeof(uint32_t)) != sizeof(uint32_t)) {
+    for (auto index = size_t{0}; index < max_read_data_size; ++index) {
+      lseek(fd, uint32_t_size * random_indices[index], SEEK_SET);
+      if (read(fd, read_data_start + index, uint32_t_size) != uint32_t_size) {
         Fail("read error: " + strerror(errno));
       }
+      // Assert(read(fd, read_data_start + index, uint32_t_size) != uint32_t_size, "read error: " + strerror(errno));
     }
     state.PauseTiming();
 
-    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
 
     state.ResumeTiming();
@@ -127,26 +138,33 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)(ben
   if ((fd = open("file.txt", O_RDONLY)) < 0) {
     std::cout << "open error " << errno << std::endl;
   }
-  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+
+  const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
+  const auto read_data_size = NUMBER_OF_BYTES / 4;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
 
   for (auto _ : state) {
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
     std::vector<uint32_t> read_data;
-    auto read_data_size = NUMBER_OF_BYTES / 4;
     read_data.resize(read_data_size);
+    auto* read_data_start = std::data(read_data);
 
     state.ResumeTiming();
 
-    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
-      if (pread(fd, std::data(read_data) + index, sizeof(uint32_t), sizeof(uint32_t) * index) != sizeof(uint32_t)) {
+    for (auto index = size_t{0}; index < max_read_data_size; ++index) {
+      if (pread(fd, read_data_start + index, uint32_t_size, uint32_t_size * index) != uint32_t_size) {
         Fail("read error: " + strerror(errno));
       }
+      // TODO Find out why permission error
+      // Assert(pread(fd, read_data_start + index, uint32_t_size, uint32_t_size * index) != uint32_t_size,
+      //       "read error: " + strerror(errno));
     }
     state.PauseTiming();
 
-    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
 
     state.ResumeTiming();
@@ -158,25 +176,29 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchma
   if ((fd = open("file.txt", O_RDONLY)) < 0) {
     std::cout << "open error " << errno << std::endl;
   }
-  const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+
+  const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
+  const auto read_data_size = NUMBER_OF_BYTES / 4;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
 
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
     std::vector<uint32_t> read_data;
-    auto read_data_size = NUMBER_OF_BYTES / 4;
     read_data.resize(read_data_size);
+    auto* read_data_start = std::data(read_data);
+
     state.ResumeTiming();
 
-    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
-      if (pread(fd, std::data(read_data) + index, sizeof(uint32_t), sizeof(uint32_t) * random_indices[index]) !=
-          sizeof(uint32_t)) {
+    for (auto index = size_t{0}; index < max_read_data_size; ++index) {
+      if (pread(fd, read_data_start + index, uint32_t_size, uint32_t_size * random_indices[index]) != uint32_t_size) {
         Fail("read error: " + strerror(errno));
       }
     }
     state.PauseTiming();
 
-    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
 
     state.ResumeTiming();
@@ -184,21 +206,23 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchma
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(benchmark::State& state) {  // open file
-  for (auto _ : state) {
-    const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+  const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
+  const auto read_data_size = NUMBER_OF_BYTES / 4;
+  const auto max_read_data_size = static_cast<size_t>(read_data_size);
 
+  for (auto _ : state) {
     state.PauseTiming();
     std::vector<uint32_t> read_data;
-    auto read_data_size = NUMBER_OF_BYTES / 4;
     read_data.resize(read_data_size);
+
     state.ResumeTiming();
 
-    for (auto index = size_t{0}; index < static_cast<size_t>(read_data_size); ++index) {
+    for (auto index = size_t{0}; index < max_read_data_size; ++index) {
       read_data[index] = numbers[index];
     }
 
     state.PauseTiming();
-    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
 
     Assert(control_sum == sum, "Sanity check failed: Not the same result");
     Assert(&read_data != &numbers, "Sanity check failed: Same reference");
@@ -208,12 +232,12 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(b
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(benchmark::State& state) {  // open file
-  for (auto _ : state) {
-    const int32_t NUMBER_OF_BYTES = state.range(0) * MB;
+  const auto NUMBER_OF_BYTES = int32_t{static_cast<int32_t>(state.range(0) * MB)};
+  const auto random_read_amount = static_cast<size_t>(NUMBER_OF_BYTES / 4);
 
+  for (auto _ : state) {
     state.PauseTiming();
     std::vector<uint32_t> read_data;
-    auto random_read_amount = static_cast<size_t>(NUMBER_OF_BYTES / 4);
     read_data.resize(random_read_amount);
     state.ResumeTiming();
 
@@ -222,7 +246,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
     }
 
     state.PauseTiming();
-    auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
 
     Assert(control_sum == static_cast<uint64_t>(sum), "Sanity check failed: Not the same result");
     Assert(&read_data[0] != &numbers[random_indices[0]], "Sanity check failed: Same reference");
@@ -232,13 +256,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)->Arg(10);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)->Arg(10);
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)->Arg(10);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10);
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10);
 
 }  // namespace hyrise


### PR DESCRIPTION
This PR adds randomized read benchmarks and adapts the sequential reads to enable comparibility between the benchmarks.
For each benchmarks we measure a for loop for sequential and random accesses to the data. Unfortunately, I was not able to do it without a for loop. Please, if you have an idea for this, feel free to comment it.

I'd also be happy about some feedback :)
 Current Benchmark results, once with and once without in memory reads
![Figure_1](https://user-images.githubusercontent.com/38314662/201966667-279949ed-907b-4499-b4cf-408d434b1ebd.png)
![Figure_2](https://user-images.githubusercontent.com/38314662/201966682-a603dc3f-fa9b-440d-8b37-96e35ce9e88c.png)
