### PR TITLE
Threaded read benchmarks

### DIFF
--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -20,6 +20,19 @@ void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32
   Assert((read(fd, read_data_start + from, bytes_to_read) == bytes_to_read), fail_and_close_file(fd, "Read error: ", errno));
 }
 
+void read_data_randomly_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start, const std::vector<uint32_t>& random_indices){
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto values_to_read = static_cast<ssize_t>((to - from));
+
+  lseek(fd, 0, SEEK_SET);
+  // TODO Randomize inidzes to not read all the data but really randomize the reads to read same amount but incl possible duplicates
+  for (auto index = ssize_t{0}; index < values_to_read; ++index) {
+    lseek(fd, uint32_t_size * random_indices[index], SEEK_SET);
+    Assert((read(fd, read_data_start + from + index, uint32_t_size) == uint32_t_size),
+           fail_and_close_file(fd, "Read error: ", errno));
+  }
+}
+
 void read_data_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start){
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
   const auto bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
@@ -99,6 +112,85 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark:
   }
 
   close(fd);
+}
+
+void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(benchmark::State& state){
+  auto fd = int32_t{};
+  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+
+    micro_benchmark_clear_disk_cache();
+    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    auto read_data = std::vector<uint32_t>{};
+    read_data.resize(NUMBER_OF_ELEMENTS);
+
+    state.ResumeTiming();
+
+    lseek(fd, 0, SEEK_SET);
+    // TODO Randomize inidzes to not read all the data but really randomize the reads to read same amount but incl possible duplicates
+    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+      lseek(fd, uint32_t_size * random_indices[index], SEEK_SET);
+      Assert((read(fd, std::data(read_data) + index, uint32_t_size) == uint32_t_size),
+             fail_and_close_file(fd, "Read error: ", errno));
+    }
+
+    state.PauseTiming();
+
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+
+    state.ResumeTiming();
+  }
+
+  close(fd);
+}
+
+void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count){
+  auto filedescriptors = std::vector<int32_t>(thread_count);
+  for (auto i = size_t{0}; i < thread_count; i++) {
+    auto fd = int32_t{};
+    Assert(((fd = open(filename, O_RDONLY)) >= 0),fail_and_close_file(fd, "Open error: ", errno));
+    filedescriptors[i] = fd;
+  }
+
+  auto threads = std::vector<std::thread>(thread_count);
+  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+
+    micro_benchmark_clear_disk_cache();
+    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    auto read_data = std::vector<uint32_t>{};
+    read_data.resize(NUMBER_OF_ELEMENTS);
+
+    state.ResumeTiming();
+    for (auto i = size_t{0}; i < thread_count; i++){
+      auto from = batch_size * i;
+      auto to = from + batch_size;
+      if (to >= NUMBER_OF_ELEMENTS) {
+        to = NUMBER_OF_ELEMENTS;
+      }
+      threads[i] = (std::thread(read_data_randomly_using_read, from, to, filedescriptors[i], std::data(read_data), random_indices));
+    }
+
+    for (auto i = size_t{0}; i < thread_count; i++) {
+      // Explain: Blocks the current thread until the thread identified by *this finishes its execution
+      threads[i].join();
+    }
+    state.PauseTiming();
+
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+
+    state.ResumeTiming();
+  }
+
+  for (auto i = size_t{0}; i < thread_count; i++) {
+    close(filedescriptors[i]);
+  }
 }
 
 void FileIOMicroReadBenchmarkFixture::pread_non_atomic_single_threaded(benchmark::State& state){
@@ -186,37 +278,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_T
   }
 }
 
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)(benchmark::State& state) {  // open file
-  auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
-
-  for (auto _ : state) {
-    state.PauseTiming();
-
-    micro_benchmark_clear_disk_cache();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
-    auto read_data = std::vector<uint32_t>{};
-    read_data.resize(NUMBER_OF_ELEMENTS);
-
-    state.ResumeTiming();
-
-    lseek(fd, 0, SEEK_SET);
-    // TODO Randomize inidzes to not read all the data but really randomize the reads to read same amount but incl possible duplicates
-    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
-      lseek(fd, uint32_t_size * random_indices[index], SEEK_SET);
-      Assert((read(fd, std::data(read_data) + index, uint32_t_size) == uint32_t_size),
-             fail_and_close_file(fd, "Read error: ", errno));
-    }
-
-    state.PauseTiming();
-
-    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
-
-    state.ResumeTiming();
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)(benchmark::State& state) {
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if(thread_count == 1){
+    read_non_atomic_random_single_threaded(state);
+  } else {
+    read_non_atomic_random_multi_threaded(state, thread_count);
   }
-
-  close(fd);
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)(benchmark::State& state) {
@@ -304,19 +372,21 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)->ArgsProduct({
+/*BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)->ArgsProduct({
+    {10},
+    {1, 2, 4, 6, 8, 16, 32}
+})->UseRealTime();*/
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)->ArgsProduct({
     {10},
     {1, 2, 4, 6, 8, 16, 32}
 })->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
-
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)->ArgsProduct({
+/*BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)->ArgsProduct({
    {10},
    {1, 2, 4, 6, 8, 16, 32}
 })->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10)->Arg(100)->Arg(1000);*/
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -22,13 +22,12 @@ void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32
 
 void read_data_randomly_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start, const std::vector<uint32_t>& random_indices){
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
-  const auto values_to_read = static_cast<ssize_t>((to - from));
 
   lseek(fd, 0, SEEK_SET);
   // TODO Randomize inidzes to not read all the data but really randomize the reads to read same amount but incl possible duplicates
-  for (auto index = ssize_t{0}; index < values_to_read; ++index) {
+  for (auto index = from; index < to; ++index) {
     lseek(fd, uint32_t_size * random_indices[index], SEEK_SET);
-    Assert((read(fd, read_data_start + from + index, uint32_t_size) == uint32_t_size),
+    Assert((read(fd, read_data_start + index, uint32_t_size) == uint32_t_size),
            fail_and_close_file(fd, "Read error: ", errno));
   }
 }

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -7,12 +7,73 @@
 #include <iterator>
 #include <numeric>
 #include <random>
+#include <thread>
 #include "file_io_read_micro_benchmark.hpp"
 #include "micro_benchmark_basic_fixture.hpp"
 
 namespace hyrise {
 
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)(benchmark::State& state) {  // open file
+void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start){
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
+  lseek(fd, from * uint32_t_size, SEEK_SET);
+  Assert((read(fd, read_data_start + from, bytes_to_read) == bytes_to_read), fail_and_close_file(fd, "Read error: ", errno));
+}
+
+void read_data_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start){
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
+  lseek(fd, from * uint32_t_size, SEEK_SET);
+  Assert((pread(fd, read_data_start + from, bytes_to_read, from * uint32_t_size) == bytes_to_read), fail_and_close_file(fd, "Read error: ", errno));
+}
+
+void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count){
+  auto filedescriptors = std::vector<int32_t>(thread_count);
+  for (auto i = size_t{0}; i < thread_count; i++) {
+    auto fd = int32_t{};
+    Assert(((fd = open(filename, O_RDONLY)) >= 0),fail_and_close_file(fd, "Open error: ", errno));
+    filedescriptors[i] = fd;
+  }
+
+  auto threads = std::vector<std::thread>(thread_count);
+  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+
+    micro_benchmark_clear_disk_cache();
+    auto read_data = std::vector<uint32_t>{};
+    read_data.resize(NUMBER_OF_ELEMENTS);
+    auto* read_data_start = std::data(read_data);
+
+    state.ResumeTiming();
+
+    for (auto i = size_t{0}; i < thread_count; i++){
+      auto from = batch_size * i;
+      auto to = from + batch_size;
+      if (to >= NUMBER_OF_ELEMENTS) {
+        to = NUMBER_OF_ELEMENTS;
+      }
+      threads[i] = (std::thread(read_data_using_read, from, to, filedescriptors[i], read_data_start));
+    }
+
+    for (auto i = size_t{0}; i < thread_count; i++) {
+      // Explain: Blocks the current thread until the thread identified by *this finishes its execution
+      threads[i].join();
+    }
+    state.PauseTiming();
+
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    state.ResumeTiming();
+  }
+
+  for (auto i = size_t{0}; i < thread_count; i++) {
+    close(filedescriptors[i]);
+  }
+}
+
+void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -38,6 +99,91 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)(
   }
 
   close(fd);
+}
+
+void FileIOMicroReadBenchmarkFixture::pread_non_atomic_single_threaded(benchmark::State& state){
+  auto fd = int32_t{};
+  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+
+    micro_benchmark_clear_disk_cache();
+    auto read_data = std::vector<uint32_t>{};
+    read_data.resize(NUMBER_OF_ELEMENTS);
+    state.ResumeTiming();
+
+    read_data.resize(NUMBER_OF_ELEMENTS);
+
+    state.ResumeTiming();
+
+    Assert((pread(fd, std::data(read_data), NUMBER_OF_BYTES, 0) == NUMBER_OF_BYTES),
+           fail_and_close_file(fd, "Read error: ", errno));
+
+    state.PauseTiming();
+
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    state.ResumeTiming();
+  }
+
+  close(fd);
+}
+
+void FileIOMicroReadBenchmarkFixture::pread_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count){
+  auto filedescriptors = std::vector<int32_t>(thread_count);
+  for (auto i = size_t{0}; i < thread_count; i++) {
+    auto fd = int32_t{};
+    Assert(((fd = open(filename, O_RDONLY)) >= 0),fail_and_close_file(fd, "Open error: ", errno));
+    filedescriptors[i] = fd;
+  }
+
+  auto threads = std::vector<std::thread>(thread_count);
+  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+
+    micro_benchmark_clear_disk_cache();
+    auto read_data = std::vector<uint32_t>{};
+    read_data.resize(NUMBER_OF_ELEMENTS);
+    auto* read_data_start = std::data(read_data);
+
+    state.ResumeTiming();
+
+    for (auto i = size_t{0}; i < thread_count; i++){
+      auto from = batch_size * i;
+      auto to = from + batch_size;
+      if (to >= NUMBER_OF_ELEMENTS) {
+        to = NUMBER_OF_ELEMENTS;
+      }
+      threads[i] = (std::thread(read_data_using_pread, from, to, filedescriptors[i], read_data_start));
+    }
+
+    for (auto i = size_t{0}; i < thread_count; i++) {
+      // Explain: Blocks the current thread until the thread identified by *this finishes its execution
+      threads[i].join();
+    }
+    state.PauseTiming();
+
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    state.ResumeTiming();
+  }
+
+  for (auto i = size_t{0}; i < thread_count; i++) {
+    close(filedescriptors[i]);
+  }
+}
+
+
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)(benchmark::State& state) {
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if(thread_count == 1){
+    read_non_atomic_single_threaded(state);
+  } else {
+    read_non_atomic_multi_threaded(state, thread_count);
+  }
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)(benchmark::State& state) {  // open file
@@ -73,33 +219,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)(benc
   close(fd);
 }
 
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)(benchmark::State& state) {
-  auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
-
-  for (auto _ : state) {
-    state.PauseTiming();
-
-    micro_benchmark_clear_disk_cache();
-    auto read_data = std::vector<uint32_t>{};
-    read_data.resize(NUMBER_OF_ELEMENTS);
-    state.ResumeTiming();
-
-    read_data.resize(NUMBER_OF_ELEMENTS);
-
-    state.ResumeTiming();
-
-    Assert((pread(fd, std::data(read_data), NUMBER_OF_BYTES, 0) == NUMBER_OF_BYTES),
-           fail_and_close_file(fd, "Read error: ", errno));
-
-    state.PauseTiming();
-
-    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
-    state.ResumeTiming();
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)(benchmark::State& state) {
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if(thread_count == 1){
+    pread_non_atomic_single_threaded(state);
+  } else {
+    pread_non_atomic_multi_threaded(state, thread_count);
   }
-
-  close(fd);
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchmark::State& state) {
@@ -178,10 +304,16 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)->ArgsProduct({
+    {10},
+    {1, 2, 4, 6, 8, 16, 32}
+})->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)->ArgsProduct({
+   {10},
+   {1, 2, 4, 6, 8, 16, 32}
+})->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -54,6 +54,7 @@ void read_data_randomly_using_pread(const size_t from, const size_t to, int32_t 
   }
 }
 
+// TODO(everyone): Reduce LOC by making this function more modular (do not repeat it with different function inputs).
 void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto i = size_t{0}; i < thread_count; i++) {

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -13,14 +13,16 @@
 
 namespace hyrise {
 
-void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start){
+void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start) {
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
   const auto bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
   lseek(fd, from * uint32_t_size, SEEK_SET);
-  Assert((read(fd, read_data_start + from, bytes_to_read) == bytes_to_read), fail_and_close_file(fd, "Read error: ", errno));
+  Assert((read(fd, read_data_start + from, bytes_to_read) == bytes_to_read),
+         fail_and_close_file(fd, "Read error: ", errno));
 }
 
-void read_data_randomly_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start, const std::vector<uint32_t>& random_indices){
+void read_data_randomly_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start,
+                                   const std::vector<uint32_t>& random_indices) {
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
 
   lseek(fd, 0, SEEK_SET);
@@ -32,18 +34,31 @@ void read_data_randomly_using_read(const size_t from, const size_t to, int32_t f
   }
 }
 
-void read_data_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start){
+void read_data_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start) {
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
   const auto bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
   lseek(fd, from * uint32_t_size, SEEK_SET);
-  Assert((pread(fd, read_data_start + from, bytes_to_read, from * uint32_t_size) == bytes_to_read), fail_and_close_file(fd, "Read error: ", errno));
+  Assert((pread(fd, read_data_start + from, bytes_to_read, from * uint32_t_size) == bytes_to_read),
+         fail_and_close_file(fd, "Read error: ", errno));
 }
 
-void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count){
+void read_data_randomly_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start,
+                                    const std::vector<uint32_t>& random_indices) {
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+
+  lseek(fd, 0, SEEK_SET);
+  // TODO Randomize inidzes to not read all the data but really randomize the reads to read same amount but incl possible duplicates
+  for (auto index = from; index < to; ++index) {
+    Assert((pread(fd, read_data_start + index, uint32_t_size, uint32_t_size * random_indices[index]) == uint32_t_size),
+           fail_and_close_file(fd, "Read error: ", errno));
+  }
+}
+
+void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto i = size_t{0}; i < thread_count; i++) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename, O_RDONLY)) >= 0),fail_and_close_file(fd, "Open error: ", errno));
+    Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
     filedescriptors[i] = fd;
   }
 
@@ -60,7 +75,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::
 
     state.ResumeTiming();
 
-    for (auto i = size_t{0}; i < thread_count; i++){
+    for (auto i = size_t{0}; i < thread_count; i++) {
       auto from = batch_size * i;
       auto to = from + batch_size;
       if (to >= NUMBER_OF_ELEMENTS) {
@@ -113,7 +128,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark:
   close(fd);
 }
 
-void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(benchmark::State& state){
+void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -146,11 +161,12 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(ben
   close(fd);
 }
 
-void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count){
+void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benchmark::State& state,
+                                                                            uint16_t thread_count) {
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto i = size_t{0}; i < thread_count; i++) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename, O_RDONLY)) >= 0),fail_and_close_file(fd, "Open error: ", errno));
+    Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
     filedescriptors[i] = fd;
   }
 
@@ -166,13 +182,14 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
     read_data.resize(NUMBER_OF_ELEMENTS);
 
     state.ResumeTiming();
-    for (auto i = size_t{0}; i < thread_count; i++){
+    for (auto i = size_t{0}; i < thread_count; i++) {
       auto from = batch_size * i;
       auto to = from + batch_size;
       if (to >= NUMBER_OF_ELEMENTS) {
         to = NUMBER_OF_ELEMENTS;
       }
-      threads[i] = (std::thread(read_data_randomly_using_read, from, to, filedescriptors[i], std::data(read_data), random_indices));
+      threads[i] = (std::thread(read_data_randomly_using_read, from, to, filedescriptors[i], std::data(read_data),
+                                random_indices));
     }
 
     for (auto i = size_t{0}; i < thread_count; i++) {
@@ -192,7 +209,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
   }
 }
 
-void FileIOMicroReadBenchmarkFixture::pread_non_atomic_single_threaded(benchmark::State& state){
+void FileIOMicroReadBenchmarkFixture::pread_non_atomic_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -221,11 +238,11 @@ void FileIOMicroReadBenchmarkFixture::pread_non_atomic_single_threaded(benchmark
   close(fd);
 }
 
-void FileIOMicroReadBenchmarkFixture::pread_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count){
+void FileIOMicroReadBenchmarkFixture::pread_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto i = size_t{0}; i < thread_count; i++) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename, O_RDONLY)) >= 0),fail_and_close_file(fd, "Open error: ", errno));
+    Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
     filedescriptors[i] = fd;
   }
 
@@ -242,7 +259,7 @@ void FileIOMicroReadBenchmarkFixture::pread_non_atomic_multi_threaded(benchmark:
 
     state.ResumeTiming();
 
-    for (auto i = size_t{0}; i < thread_count; i++){
+    for (auto i = size_t{0}; i < thread_count; i++) {
       auto from = batch_size * i;
       auto to = from + batch_size;
       if (to >= NUMBER_OF_ELEMENTS) {
@@ -267,35 +284,7 @@ void FileIOMicroReadBenchmarkFixture::pread_non_atomic_multi_threaded(benchmark:
   }
 }
 
-
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)(benchmark::State& state) {
-  auto thread_count = static_cast<uint16_t>(state.range(1));
-  if(thread_count == 1){
-    read_non_atomic_single_threaded(state);
-  } else {
-    read_non_atomic_multi_threaded(state, thread_count);
-  }
-}
-
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)(benchmark::State& state) {
-  auto thread_count = static_cast<uint16_t>(state.range(1));
-  if(thread_count == 1){
-    read_non_atomic_random_single_threaded(state);
-  } else {
-    read_non_atomic_random_multi_threaded(state, thread_count);
-  }
-}
-
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)(benchmark::State& state) {
-  auto thread_count = static_cast<uint16_t>(state.range(1));
-  if(thread_count == 1){
-    pread_non_atomic_single_threaded(state);
-  } else {
-    pread_non_atomic_multi_threaded(state, thread_count);
-  }
-}
-
-BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchmark::State& state) {
+void FileIOMicroReadBenchmarkFixture::pread_non_atomic_random_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -324,6 +313,90 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)(benchma
   }
 
   close(fd);
+}
+
+void FileIOMicroReadBenchmarkFixture::pread_non_atomic_random_multi_threaded(benchmark::State& state,
+                                                                             uint16_t thread_count) {
+  auto filedescriptors = std::vector<int32_t>(thread_count);
+  for (auto i = size_t{0}; i < thread_count; i++) {
+    auto fd = int32_t{};
+    Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
+    filedescriptors[i] = fd;
+  }
+
+  auto threads = std::vector<std::thread>(thread_count);
+  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+
+    micro_benchmark_clear_disk_cache();
+    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    auto read_data = std::vector<uint32_t>{};
+    read_data.resize(NUMBER_OF_ELEMENTS);
+
+    state.ResumeTiming();
+    for (auto i = size_t{0}; i < thread_count; i++) {
+      auto from = batch_size * i;
+      auto to = from + batch_size;
+      if (to >= NUMBER_OF_ELEMENTS) {
+        to = NUMBER_OF_ELEMENTS;
+      }
+      threads[i] = (std::thread(read_data_randomly_using_pread, from, to, filedescriptors[i], std::data(read_data),
+                                random_indices));
+    }
+
+    for (auto i = size_t{0}; i < thread_count; i++) {
+      // Explain: Blocks the current thread until the thread identified by *this finishes its execution
+      threads[i].join();
+    }
+    state.PauseTiming();
+
+    const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+
+    state.ResumeTiming();
+  }
+
+  for (auto i = size_t{0}; i < thread_count; i++) {
+    close(filedescriptors[i]);
+  }
+}
+
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)(benchmark::State& state) {
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if (thread_count == 1) {
+    read_non_atomic_single_threaded(state);
+  } else {
+    read_non_atomic_multi_threaded(state, thread_count);
+  }
+}
+
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)(benchmark::State& state) {
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if (thread_count == 1) {
+    read_non_atomic_random_single_threaded(state);
+  } else {
+    read_non_atomic_random_multi_threaded(state, thread_count);
+  }
+}
+
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)(benchmark::State& state) {
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if (thread_count == 1) {
+    pread_non_atomic_single_threaded(state);
+  } else {
+    pread_non_atomic_multi_threaded(state, thread_count);
+  }
+}
+
+BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)(benchmark::State& state) {
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if (thread_count == 1) {
+    pread_non_atomic_random_single_threaded(state);
+  } else {
+    pread_non_atomic_random_multi_threaded(state, thread_count);
+  }
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(benchmark::State& state) {
@@ -371,21 +444,19 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
-/*BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)->ArgsProduct({
-    {10},
-    {1, 2, 4, 6, 8, 16, 32}
-})->UseRealTime();*/
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)->ArgsProduct({
-    {10},
-    {1, 2, 4, 6, 8, 16, 32}
-})->UseRealTime();
-/*BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)->ArgsProduct({
-   {10},
-   {1, 2, 4, 6, 8, 16, 32}
-})->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
-
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
+    ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 6, 8, 16, 32}})
+    ->UseRealTime();
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
+    ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 6, 8, 16, 32}})
+    ->UseRealTime();
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
+    ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 6, 8, 16, 32}})
+    ->UseRealTime();
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)
+    ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 6, 8, 16, 32}})
+    ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10)->Arg(100)->Arg(1000);*/
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -40,6 +40,8 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   std::vector<uint32_t> numbers = std::vector<uint32_t>{};
   void read_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void read_non_atomic_single_threaded(benchmark::State& state);
+  void read_non_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count);
+  void read_non_atomic_random_single_threaded(benchmark::State& state);
   void pread_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void pread_non_atomic_single_threaded(benchmark::State& state);
 };

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -38,5 +38,9 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   uint32_t NUMBER_OF_BYTES = uint32_t{0};
   uint32_t NUMBER_OF_ELEMENTS = uint32_t{0};
   std::vector<uint32_t> numbers = std::vector<uint32_t>{};
+  void read_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count);
+  void read_non_atomic_single_threaded(benchmark::State& state);
+  void pread_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count);
+  void pread_non_atomic_single_threaded(benchmark::State& state);
 };
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -44,5 +44,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void read_non_atomic_random_single_threaded(benchmark::State& state);
   void pread_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void pread_non_atomic_single_threaded(benchmark::State& state);
+  void pread_non_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count);
+  void pread_non_atomic_random_single_threaded(benchmark::State& state);
 };
 }  // namespace hyrise


### PR DESCRIPTION
Note: will be merged into refactoring/read_benchmark

This PR introduces threaded benchmarks into our read benchmark suite.  (for pread and read, in memory not necessary)
Every benchmark has 2 versions: one with a single thread and one with multiple threads.
The benchmarking overhead is quite simple, if any questions regarding this come up, feel free to ask me :smile: 