### PR TITLE
mmap read threaded

### DIFF
--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -46,5 +46,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void pread_atomic_single_threaded(benchmark::State& state);
   void pread_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void pread_atomic_random_single_threaded(benchmark::State& state);
+  void mmap_read_single_threaded_sequential(benchmark::State& state, int mmap_mode_flag);
+  void mmap_read_multi_threaded_sequential(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count);
 };
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -46,9 +46,12 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void pread_atomic_single_threaded(benchmark::State& state);
   void pread_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void pread_atomic_random_single_threaded(benchmark::State& state);
-  void mmap_read_single_threaded_sequential(benchmark::State& state, int mmap_mode_flag);
-  void mmap_read_multi_threaded_sequential(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count);
+  void mmap_read_single_threaded(benchmark::State& state, int mmap_mode_flag, int access_order);
+  void mmap_read_multi_threaded(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count, int access_order);
   void mmap_read_single_threaded_random(benchmark::State& state, int mmap_mode_flag);
   void mmap_read_multi_threaded_random(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count);
+
+  enum DATA_ACCESS_TYPES { SEQUENTIAL, RANDOM };
+  enum MMAP_ACCESS_TYPES { SHARED, PRIVATE };
 };
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -46,9 +46,9 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void pread_atomic_single_threaded(benchmark::State& state);
   void pread_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void pread_atomic_random_single_threaded(benchmark::State& state);
-  void mmap_read_single_threaded(benchmark::State& state, int mmap_mode_flag, int access_order);
-  void mmap_read_multi_threaded(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count, int access_order);
-
+  void mmap_read_single_threaded(benchmark::State state, const int mmap_mode_flag, const int access_order);
+  void mmap_read_multi_threaded(benchmark::State& state, const int mmap_mode_flag, const uint16_t thread_count, const int access_order);
+  // enums for mmap benchmarks
   enum DATA_ACCESS_TYPES { SEQUENTIAL, RANDOM };
   enum MMAP_ACCESS_TYPES { SHARED = MAP_SHARED, PRIVATE = MAP_PRIVATE };
 };

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -48,5 +48,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void pread_atomic_random_single_threaded(benchmark::State& state);
   void mmap_read_single_threaded_sequential(benchmark::State& state, int mmap_mode_flag);
   void mmap_read_multi_threaded_sequential(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count);
+  void mmap_read_single_threaded_random(benchmark::State& state, int mmap_mode_flag);
+  void mmap_read_multi_threaded_random(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count);
 };
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -48,10 +48,8 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void pread_atomic_random_single_threaded(benchmark::State& state);
   void mmap_read_single_threaded(benchmark::State& state, int mmap_mode_flag, int access_order);
   void mmap_read_multi_threaded(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count, int access_order);
-  void mmap_read_single_threaded_random(benchmark::State& state, int mmap_mode_flag);
-  void mmap_read_multi_threaded_random(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count);
 
   enum DATA_ACCESS_TYPES { SEQUENTIAL, RANDOM };
-  enum MMAP_ACCESS_TYPES { SHARED, PRIVATE };
+  enum MMAP_ACCESS_TYPES { SHARED = MAP_SHARED, PRIVATE = MAP_PRIVATE };
 };
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -10,13 +10,15 @@ void read_mmap_chunk_sequential(const size_t from, const size_t to, const int32_
   }
 }
 
-void read_mmap_chunk_randomly(const size_t from, const size_t to, const int32_t* map, uint64_t& sum, const std::vector<uint32_t>& random_indexes) {
+void read_mmap_chunk_random(const size_t from, const size_t to, const int32_t* map, uint64_t& sum,
+                            const std::vector<uint32_t>& random_indexes) {
   for (auto index = size_t{0} + from; index < to; ++index) {
     sum += map[random_indexes[index]];
   }
 }
 
-void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded_sequential(benchmark::State& state, int mmap_mode_flag){
+void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded(benchmark::State& state, int mmap_mode_flag,
+                                                                int access_order) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -31,8 +33,11 @@ void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded_sequential(bench
     auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, mmap_mode_flag, fd, OFFSET));
     Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping Failed: ", errno));
 
-    madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
-
+    if (access_order == RANDOM) {
+      madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
+    } else {
+      madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
+    }
     auto sum = uint64_t{0};
     for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
       sum += map[index];
@@ -49,7 +54,8 @@ void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded_sequential(bench
   close(fd);
 }
 
-void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded_sequential(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count){
+void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded(benchmark::State& state, int mmap_mode_flag,
+                                                               uint16_t thread_count, int access_order) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -68,99 +74,29 @@ void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded_sequential(benchm
     auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, mmap_mode_flag, fd, OFFSET));
     Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping Failed: ", errno));
 
-    madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
+    if (access_order == RANDOM) {
+      state.PauseTiming();
+      const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
+      state.ResumeTiming();
 
-    for (auto i = size_t{0}; i < thread_count; i++) {
-      auto from = batch_size * i;
-      auto to = std::min(from + batch_size, uint64_t {NUMBER_OF_ELEMENTS});
-      // std::ref fix from https://stackoverflow.com/a/73642536
-      threads[i] = std::thread(read_mmap_chunk_sequential, from, to, map, std::ref(sums[i]));
+      madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
+
+      for (auto i = size_t{0}; i < thread_count; i++) {
+        auto from = batch_size * i;
+        auto to = std::min(from + batch_size, uint64_t{NUMBER_OF_ELEMENTS});
+        // std::ref fix from https://stackoverflow.com/a/73642536
+        threads[i] = std::thread(read_mmap_chunk_random, from, to, map, std::ref(sums[i]), random_indexes);
+      }
+    } else {
+      madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
+
+      for (auto i = size_t{0}; i < thread_count; i++) {
+        auto from = batch_size * i;
+        auto to = std::min(from + batch_size, uint64_t{NUMBER_OF_ELEMENTS});
+        // std::ref fix from https://stackoverflow.com/a/73642536
+        threads[i] = std::thread(read_mmap_chunk_sequential, from, to, map, std::ref(sums[i]));
+      }
     }
-
-    for (auto i = size_t{0}; i < thread_count; i++) {
-      // Blocks the current thread until the thread identified by *this finishes its execution
-      threads[i].join();
-    }
-    state.PauseTiming();
-    auto total_sum = std::accumulate(sums.begin(), sums.end(), uint64_t{0});
-
-    Assert(control_sum == total_sum, "Sanity check failed: Not the same result");
-    state.ResumeTiming();
-
-    Assert(msync(map, NUMBER_OF_BYTES, MS_SYNC) != -1, "Mapping Syncing Failed:" + std::strerror(errno));
-    state.PauseTiming();
-
-    // Remove memory mapping after job is done.
-    Assert((munmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
-    state.ResumeTiming();
-  }
-
-  close(fd);
-}
-
-void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded_random(benchmark::State& state, int mmap_mode_flag){
-  auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
-    micro_benchmark_clear_disk_cache();
-    state.ResumeTiming();
-
-    // Getting the mapping to memory.
-    const auto OFFSET = off_t{0};
-
-    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, mmap_mode_flag, fd, OFFSET));
-    Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping failed: ", errno));
-
-    madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
-
-    auto sum = uint64_t{0};
-    for (size_t index = 0; index < NUMBER_OF_ELEMENTS; ++index) {
-      sum += map[random_indices[index]];
-    }
-
-    state.PauseTiming();
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
-    state.ResumeTiming();
-
-    // Remove memory mapping after job is done.
-    Assert((munmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
-  }
-  close(fd);
-}
-
-void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded_random(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count){
-  auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
-
-  auto threads = std::vector<std::thread>(thread_count);
-  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    micro_benchmark_clear_disk_cache();
-    auto sums = std::vector<uint64_t>(thread_count, 0);
-    // Generating random indexes should not play a role in the benchmark.
-    const auto ind_access_order = generate_random_indexes(NUMBER_OF_ELEMENTS);
-    state.ResumeTiming();
-
-    // Getting the mapping to memory.
-    const auto OFFSET = off_t{0};
-
-    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, mmap_mode_flag, fd, OFFSET));
-    Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping Failed: ", errno));
-
-    madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
-
-    for (auto i = size_t{0}; i < thread_count; i++) {
-      auto from = batch_size * i;
-      auto to = std::min(from + batch_size, uint64_t {NUMBER_OF_ELEMENTS});
-      // std::ref fix from https://stackoverflow.com/a/73642536
-      threads[i] = std::thread(read_mmap_chunk_randomly, from, to, map, std::ref(sums[i]), ind_access_order);
-    }
-
     for (auto i = size_t{0}; i < thread_count; i++) {
       // Blocks the current thread until the thread identified by *this finishes its execution
       threads[i].join();
@@ -185,61 +121,36 @@ void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded_random(benchmark:
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)(benchmark::State& state) {
   auto thread_count = static_cast<uint16_t>(state.range(1));
   if (thread_count == 1) {
-    mmap_read_single_threaded_random(state, MAP_PRIVATE);
+    mmap_read_single_threaded(state, PRIVATE, RANDOM);
   } else {
-    mmap_read_multi_threaded_random(state, MAP_PRIVATE, thread_count);
+    mmap_read_multi_threaded(state, PRIVATE, thread_count, RANDOM);
   }
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)(benchmark::State& state) {
   auto thread_count = static_cast<uint16_t>(state.range(1));
   if (thread_count == 1) {
-    mmap_read_single_threaded_sequential(state, MAP_PRIVATE);
+    mmap_read_single_threaded(state, PRIVATE, SEQUENTIAL);
   } else {
-    mmap_read_multi_threaded_sequential(state, MAP_PRIVATE, thread_count);
+    mmap_read_multi_threaded(state, PRIVATE, thread_count, SEQUENTIAL);
   }
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)(benchmark::State& state) {
-  auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
-    micro_benchmark_clear_disk_cache();
-    state.ResumeTiming();
-
-    // Getting the mapping to memory.
-    const auto OFFSET = off_t{0};
-
-    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_SHARED, fd, OFFSET));
-    Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping failed: ", errno));
-
-    madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
-
-    auto sum = uint64_t{0};
-    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
-      sum += map[random_indices[index]];
-    }
-
-    state.PauseTiming();
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
-    state.ResumeTiming();
-
-    // Remove memory mapping after job is done.
-    Assert((munmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if (thread_count == 1) {
+    mmap_read_single_threaded(state, SHARED, RANDOM);
+  } else {
+    mmap_read_multi_threaded(state, SHARED, thread_count, RANDOM);
   }
-
-  close(fd);
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)(benchmark::State& state) {
   auto thread_count = static_cast<uint16_t>(state.range(1));
   if (thread_count == 1) {
-    mmap_read_single_threaded_sequential(state, MAP_SHARED);
+    mmap_read_single_threaded(state, SHARED, SEQUENTIAL);
   } else {
-    mmap_read_multi_threaded_sequential(state, MAP_SHARED, thread_count);
+    mmap_read_multi_threaded(state, SHARED, thread_count, SEQUENTIAL);
   }
 }
 

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -4,6 +4,97 @@ namespace hyrise {
 
 class FileIOReadMmapBenchmarkFixture : public FileIOMicroReadBenchmarkFixture {};
 
+void read_mmap_chunk_sequential(const size_t from, const size_t to, const int32_t* map, uint64_t& sum) {
+  for (auto index = size_t{0} + from; index < to; ++index) {
+    sum += map[index];
+  }
+}
+
+void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded_sequential(benchmark::State& state, int mmap_mode_flag){
+  auto fd = int32_t{};
+  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    micro_benchmark_clear_disk_cache();
+    state.ResumeTiming();
+
+    // Getting the mapping to memory.
+    const auto OFFSET = off_t{0};
+
+    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, mmap_mode_flag, fd, OFFSET));
+    Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping Failed: ", errno));
+
+    madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
+
+    auto sum = uint64_t{0};
+    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+      sum += map[index];
+    }
+
+    state.PauseTiming();
+    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    state.ResumeTiming();
+
+    // Remove memory mapping after job is done.
+    Assert((munmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
+  }
+
+  close(fd);
+}
+
+void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded_sequential(benchmark::State& state, int mmap_mode_flag, uint16_t thread_count){
+  auto fd = int32_t{};
+  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
+
+  auto threads = std::vector<std::thread>(thread_count);
+  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    micro_benchmark_clear_disk_cache();
+    state.ResumeTiming();
+
+    // Getting the mapping to memory.
+    const auto OFFSET = off_t{0};
+
+    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, mmap_mode_flag, fd, OFFSET));
+    Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping Failed: ", errno));
+
+    madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
+
+
+    auto sums = std::vector<uint64_t>(thread_count);
+
+    for (auto i = size_t{0}; i < thread_count; i++) {
+      auto from = batch_size * i;
+      auto to = std::min(from + batch_size, uint64_t {NUMBER_OF_ELEMENTS});
+      // std::ref fix from https://stackoverflow.com/a/73642536
+      threads[i] = std::thread(read_mmap_chunk_sequential, from, to, map, std::ref(sums[i]));
+    }
+
+    for (auto i = size_t{0}; i < thread_count; i++) {
+      // Blocks the current thread until the thread identified by *this finishes its execution
+      threads[i].join();
+    }
+    state.PauseTiming();
+    auto total_sum = std::accumulate(sums.begin(), sums.end(), uint64_t{0});
+
+    Assert(control_sum == total_sum, "Sanity check failed: Not the same result");
+    state.ResumeTiming();
+
+    Assert(msync(map, NUMBER_OF_BYTES, MS_SYNC) != -1, "Mapping Syncing Failed:" + std::strerror(errno));
+    state.PauseTiming();
+
+    // Remove memory mapping after job is done.
+    Assert((munmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
+    state.ResumeTiming();
+  }
+
+  close(fd);
+}
+
+
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)(benchmark::State& state) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
@@ -38,36 +129,12 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RAND
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)(benchmark::State& state) {
-  auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    micro_benchmark_clear_disk_cache();
-    state.ResumeTiming();
-
-    // Getting the mapping to memory.
-    const auto OFFSET = off_t{0};
-
-    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_PRIVATE, fd, OFFSET));
-    Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping Failed: ", errno));
-
-    madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
-
-    auto sum = uint64_t{0};
-    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
-      sum += map[index];
-    }
-
-    state.PauseTiming();
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
-    state.ResumeTiming();
-
-    // Remove memory mapping after job is done.
-    Assert((munmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if (thread_count == 1) {
+    mmap_read_single_threaded_sequential(state, MAP_PRIVATE);
+  } else {
+    mmap_read_multi_threaded_sequential(state, MAP_PRIVATE, thread_count);
   }
-
-  close(fd);
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)(benchmark::State& state) {
@@ -105,42 +172,22 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDO
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)(benchmark::State& state) {
-  auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    micro_benchmark_clear_disk_cache();
-    state.ResumeTiming();
-
-    // Getting the mapping to memory.
-    const auto OFFSET = off_t{0};
-
-    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_SHARED, fd, OFFSET));
-    Assert((map != MAP_FAILED), fail_and_close_file(fd, "Mapping failed: ", errno));
-
-    madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
-
-    auto sum = uint64_t{0};
-    for (size_t index = 0; index < NUMBER_OF_ELEMENTS; ++index) {
-      sum += map[index];
-    }
-
-    state.PauseTiming();
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
-    state.ResumeTiming();
-
-    // Remove memory mapping after job is done.
-    Assert((munmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
+  auto thread_count = static_cast<uint16_t>(state.range(1));
+  if (thread_count == 1) {
+    mmap_read_single_threaded_sequential(state, MAP_SHARED);
+  } else {
+    mmap_read_multi_threaded_sequential(state, MAP_SHARED, thread_count);
   }
-
-  close(fd);
 }
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32}})
+    ->UseRealTime();
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32}})
+    ->UseRealTime();
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)->Arg(10)->Arg(100)->Arg(1000);
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)->Arg(10)->Arg(100)->Arg(1000);
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32}})
+    ->UseRealTime();
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32}})
+    ->UseRealTime();
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -17,8 +17,8 @@ void read_mmap_chunk_random(const size_t from, const size_t to, const int32_t* m
   }
 }
 
-void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded(benchmark::State& state, int mmap_mode_flag,
-                                                                int access_order) {
+void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded(benchmark::State state, const int mmap_mode_flag,
+                                                                const int access_order) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -54,13 +54,13 @@ void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded(benchmark::State
   close(fd);
 }
 
-void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded(benchmark::State& state, int mmap_mode_flag,
-                                                               uint16_t thread_count, int access_order) {
+void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded(benchmark::State& state, const int mmap_mode_flag,
+                                                               const uint16_t thread_count, const int access_order) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
-  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+  const auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -81,28 +81,28 @@ void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded(benchmark::State&
 
       madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
 
-      for (auto i = size_t{0}; i < thread_count; i++) {
-        auto from = batch_size * i;
-        auto to = std::min(from + batch_size, uint64_t{NUMBER_OF_ELEMENTS});
+      for (auto i = size_t{0}; i < thread_count; ++i) {
+        const auto from = batch_size * i;
+        const auto to = std::min(from + batch_size, uint64_t{NUMBER_OF_ELEMENTS});
         // std::ref fix from https://stackoverflow.com/a/73642536
         threads[i] = std::thread(read_mmap_chunk_random, from, to, map, std::ref(sums[i]), random_indexes);
       }
     } else {
       madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
 
-      for (auto i = size_t{0}; i < thread_count; i++) {
-        auto from = batch_size * i;
-        auto to = std::min(from + batch_size, uint64_t{NUMBER_OF_ELEMENTS});
+      for (auto i = size_t{0}; i < thread_count; ++i) {
+        const auto from = batch_size * i;
+        const auto to = std::min(from + batch_size, uint64_t{NUMBER_OF_ELEMENTS});
         // std::ref fix from https://stackoverflow.com/a/73642536
         threads[i] = std::thread(read_mmap_chunk_sequential, from, to, map, std::ref(sums[i]));
       }
     }
-    for (auto i = size_t{0}; i < thread_count; i++) {
+    for (auto i = size_t{0}; i < thread_count; ++i) {
       // Blocks the current thread until the thread identified by *this finishes its execution
       threads[i].join();
     }
     state.PauseTiming();
-    auto total_sum = std::accumulate(sums.begin(), sums.end(), uint64_t{0});
+    const auto total_sum = std::accumulate(sums.begin(), sums.end(), uint64_t{0});
 
     Assert(control_sum == total_sum, "Sanity check failed: Not the same result");
     state.ResumeTiming();
@@ -119,7 +119,7 @@ void FileIOMicroReadBenchmarkFixture::mmap_read_multi_threaded(benchmark::State&
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)(benchmark::State& state) {
-  auto thread_count = static_cast<uint16_t>(state.range(1));
+  const auto thread_count = static_cast<uint16_t>(state.range(1));
   if (thread_count == 1) {
     mmap_read_single_threaded(state, PRIVATE, RANDOM);
   } else {
@@ -128,7 +128,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RAND
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)(benchmark::State& state) {
-  auto thread_count = static_cast<uint16_t>(state.range(1));
+  const auto thread_count = static_cast<uint16_t>(state.range(1));
   if (thread_count == 1) {
     mmap_read_single_threaded(state, PRIVATE, SEQUENTIAL);
   } else {
@@ -137,7 +137,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQU
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)(benchmark::State& state) {
-  auto thread_count = static_cast<uint16_t>(state.range(1));
+  const auto thread_count = static_cast<uint16_t>(state.range(1));
   if (thread_count == 1) {
     mmap_read_single_threaded(state, SHARED, RANDOM);
   } else {
@@ -146,7 +146,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDO
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)(benchmark::State& state) {
-  auto thread_count = static_cast<uint16_t>(state.range(1));
+  const auto thread_count = static_cast<uint16_t>(state.range(1));
   if (thread_count == 1) {
     mmap_read_single_threaded(state, SHARED, SEQUENTIAL);
   } else {
@@ -154,14 +154,18 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUE
   }
 }
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32}})
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
+    ->ArgsProduct({{100}, {1, 2, 4, 8, 16, 32}})
     ->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32}})
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)
+    ->ArgsProduct({{100}, {1, 2, 4, 8, 16, 32}})
     ->UseRealTime();
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32}})
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)
+    ->ArgsProduct({{100}, {1, 2, 4, 8, 16, 32}})
     ->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32}})
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)
+    ->ArgsProduct({{100}, {1, 2, 4, 8, 16, 32}})
     ->UseRealTime();
 
 }  // namespace hyrise


### PR DESCRIPTION
Hey all,

this PR introduces threads to mmap reads. It also adapts the read mmap file to the write mmap file using enum flags to reduce code lines.

I'm unsure about the reads that we do in these benchmarks. I'd expect a read into vectors, but we instead only access the entries and sum them up. Which way do you think is best?

Furthermore, I could not see any real improvements on my local machine regarding performance. See for yourself, the Time parameter almost always increases compared to the single threaded solution at 100mb. But maybe I just read these times wrongly.

```shell

Benchmark                                                                                    Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------------------------
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL/100/1/real_time    52585566 ns     52569526 ns           13
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL/100/2/real_time   113377219 ns       159549 ns            6
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL/100/4/real_time   125726069 ns       229074 ns            7
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL/100/8/real_time   118100996 ns       429964 ns            6
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL/100/16/real_time   65095992 ns       632883 ns           11
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL/100/32/real_time   41846460 ns      1002369 ns           13
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_RANDOM/100/1/real_time        58202383 ns     54119882 ns           10
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_RANDOM/100/2/real_time       704954865 ns     92886995 ns            1
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_RANDOM/100/4/real_time       408072727 ns     86028103 ns            2
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_RANDOM/100/8/real_time       348110342 ns    147310992 ns            2
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_RANDOM/100/16/real_time      349141800 ns    235242594 ns            2
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_PRIVATE_RANDOM/100/32/real_time      453634049 ns    409994499 ns            2
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL/100/1/real_time     53408138 ns     53404475 ns           10
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL/100/2/real_time    106219570 ns       163337 ns            6
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL/100/4/real_time    122192790 ns       200548 ns            6
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL/100/8/real_time    103984707 ns       399868 ns            6
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL/100/16/real_time    61053210 ns       633682 ns           11
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL/100/32/real_time    36820361 ns       980326 ns           19
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_RANDOM/100/1/real_time         47670484 ns     47666613 ns           14
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_RANDOM/100/2/real_time        521568693 ns     65335723 ns            1
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_RANDOM/100/4/real_time        366335849 ns     56861841 ns            2
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_RANDOM/100/8/real_time        391450041 ns    181633062 ns            2
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_RANDOM/100/16/real_time       341467958 ns    219107667 ns            2
FileIOMicroReadBenchmarkFixture/MMAP_ATOMIC_MAP_SHARED_RANDOM/100/32/real_time       451855405 ns    404667533 ns            2


```
