### PR TITLE
[Fix] Repair Benchmark

### DIFF
--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -46,7 +46,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void pread_atomic_single_threaded(benchmark::State& state);
   void pread_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void pread_atomic_random_single_threaded(benchmark::State& state);
-  void mmap_read_single_threaded(benchmark::State state, const int mmap_mode_flag, const int access_order);
+  void mmap_read_single_threaded(benchmark::State& state, const int mmap_mode_flag, const int access_order);
   void mmap_read_multi_threaded(benchmark::State& state, const int mmap_mode_flag, const uint16_t thread_count, const int access_order);
   // enums for mmap benchmarks
   enum DATA_ACCESS_TYPES { SEQUENTIAL, RANDOM };

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -17,7 +17,7 @@ void read_mmap_chunk_random(const size_t from, const size_t to, const int32_t* m
   }
 }
 
-void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded(benchmark::State state, const int mmap_mode_flag,
+void FileIOMicroReadBenchmarkFixture::mmap_read_single_threaded(benchmark::State& state, const int mmap_mode_flag,
                                                                 const int access_order) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));


### PR DESCRIPTION
The mmap() read benchmark on the master does not run currently.
This PR solves this issue.