### PR TITLE
[Infrastructure] Fix CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,15 +24,15 @@ jobs:
         run: |
             cd ${{github.workspace}}/hyrise/
             mkdir cmake-build-debug-clang && cd cmake-build-debug-clang
-            cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
-            make  -j
+            cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang  -DCMAKE_CXX_COMPILER=clang++ ..
+            ninja
 
       - name: Run Make with gcc
         run: |
             cd ${{github.workspace}}/hyrise/
             mkdir cmake-build-debug-gcc && cd cmake-build-debug-gcc
-            cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ..
-            make -j
+            cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ..
+            ninja
 
       - name: Run Unit Tests with clang
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,7 +3,36 @@ name: CMake GH Actions
 on: push
 
 jobs:
-  build-linux:
+  build-linux-gcc:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone Repository
+        run: git clone --recursive https://github.com/hyrise-mp-22-23/hyrise.git hyrise && cd hyrise
+
+      - name: Install Dependencies
+        run: sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-11 clang-14 clang-format-14 clang-tidy-14 cmake curl dos2unix g++-9 gcc-9 g++-11 gcc-11 gcovr git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man ninja-build parallel python3 python3-pip valgrind
+
+      - name: Install umap
+        run: |
+            git clone https://github.com/LLNL/umap.git umap && cd umap
+            mkdir build && cd build
+            cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+            sudo make install
+
+      - name: Run Make with gcc
+        run: |
+            cd ${{github.workspace}}/hyrise/
+            mkdir cmake-build-debug-gcc && cd cmake-build-debug-gcc
+            cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ..
+            ninja
+      
+      - name: Run Unit Tests with gcc
+        run: |
+            cd ${{github.workspace}}/hyrise/cmake-build-debug-gcc
+            ./hyriseTest
+    
+  build-linux-clang:
     runs-on: ubuntu-22.04
 
     steps:
@@ -27,23 +56,11 @@ jobs:
             cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang  -DCMAKE_CXX_COMPILER=clang++ ..
             ninja
 
-      - name: Run Make with gcc
-        run: |
-            cd ${{github.workspace}}/hyrise/
-            mkdir cmake-build-debug-gcc && cd cmake-build-debug-gcc
-            cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ..
-            ninja
-
       - name: Run Unit Tests with clang
         run: |
             cd ${{github.workspace}}/hyrise/cmake-build-debug-clang
             ./hyriseTest
-      
-      - name: Run Unit Tests with gcc
-        run: |
-            cd ${{github.workspace}}/hyrise/cmake-build-debug-gcc
-            ./hyriseTest
-
+            
   passive-aggressive-comments:
     runs-on: ubuntu-latest
     permissions: 


### PR DESCRIPTION
Current Builds:

![Screenshot from 2023-01-02 13-55-09](https://user-images.githubusercontent.com/50635122/210234184-6abca337-f15f-410f-a185-9de8b41a0cf0.png)

What was done:

- `make` posed a problem. It is not known which one.
- `ninja` on the other hand side does not produce this problem.
- Also, parallel `gcc` and `clang` build stages were added.

<details>
<summary>Performance GCC vs. Clang</summary>

`clang` is officially faster than `gcc`.
</details>
