### PR TITLE
Removed redundant lseek from read_using_pread

### DIFF
--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -26,7 +26,6 @@ void read_data_randomly_using_read(const size_t from, const size_t to, int32_t f
                                    const std::vector<uint32_t>& random_indices) {
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
 
-  lseek(fd, 0, SEEK_SET);
   // TODO(everyone): Randomize inidzes to not read all the data but really randomize the reads to read same amount but
   //  incl possible duplicates
   for (auto index = from; index < to; ++index) {

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -39,7 +39,6 @@ void read_data_randomly_using_read(const size_t from, const size_t to, int32_t f
 void read_data_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start) {
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
   const auto bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
-  lseek(fd, from * uint32_t_size, SEEK_SET);
   Assert((pread(fd, read_data_start + from, bytes_to_read, from * uint32_t_size) == bytes_to_read),
          fail_and_close_file(fd, "Read error: ", errno));
 }


### PR DESCRIPTION
Results from my local machine
Before
![image](https://user-images.githubusercontent.com/38314662/210966182-bd1536f9-ac07-49ba-863e-c926fb28a73c.png)


After 
![image](https://user-images.githubusercontent.com/38314662/210965783-53915383-65e5-4223-b10d-c95834c383db.png)


Brought up by Stefan here:
https://hyrise-db.slack.com/archives/C046JFXJFFS/p1672787109956039?thread_ts=1672739258.520879&cid=C046JFXJFFS