### PR TITLE
Implemented Switch for UMap

### DIFF
--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -25,7 +25,10 @@ void read_mmap_chunk_random(const size_t from, const size_t to, const int32_t* m
 
 namespace hyrise {
 
-void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag, const int access_order) {
+void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchmark::State& state,
+                                                                         const int mapping_type,
+                                                                         const int map_mode_flag,
+                                                                         const int access_order) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -44,7 +47,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
     }
 #ifdef __APPLE__
     else {
-      Fail("Error: Mapping type invalid or not supported.");
+      Fail("Error: Mapping type invalid or not supported on Apple platforms.");
     }
 #else
     else if (mapping_type == UMAP) {
@@ -58,18 +61,18 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
 
     auto sum = uint64_t{0};
     if (access_order == RANDOM) {
-        madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
-        state.PauseTiming();
-        const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
-        state.ResumeTiming();
-        for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
-          sum += map[random_indexes[index]];
-        }
+      madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
+      state.PauseTiming();
+      const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
+      state.ResumeTiming();
+      for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+        sum += map[random_indexes[index]];
+      }
     } else /* if (access_order == SEQUENTIAL) */ {
-        madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
-        for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
-          sum += map[index];
-        }
+      madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
+      for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+        sum += map[index];
+      }
     }
 
     state.PauseTiming();
@@ -82,7 +85,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
     }
 #ifdef __APPLE__
     else {
-      Fail("Error: Mapping type not supported.");
+      Fail("Error: Mapping type invalid or not supported on Apple platforms.");
     }
 #else
     else /* if (mapping_type == UMAP) */ {
@@ -93,7 +96,10 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
   close(fd);
 }
 
-void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag, const uint16_t thread_count, const int access_order) {
+void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmark::State& state, const int mapping_type,
+                                                                        const int map_mode_flag,
+                                                                        const uint16_t thread_count,
+                                                                        const int access_order) {
   auto fd = int32_t{};
   Assert(((fd = open(filename, O_RDONLY)) >= 0), fail_and_close_file(fd, "Open error: ", errno));
 
@@ -116,7 +122,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
     }
 #ifdef __APPLE__
     else {
-      Fail("Error: Mapping type invalid or not supported.");
+      Fail("Error: Mapping type invalid or not supported on Apple platforms.");
     }
 #else
     else if (mapping_type == UMAP) {
@@ -177,7 +183,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
     }
 #ifdef __APPLE__
     else {
-      Fail("Error: Mapping type not supported.");
+      Fail("Error: Mapping type invalid or not supported on Apple platforms.");
     }
 #else
     else /* if (mapping_type == UMAP) */ {

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -39,7 +39,6 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
 
     auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
 
-
     if (mapping_type == MMAP) {
       map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
     }
@@ -84,7 +83,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
     }
 #else
     else /* if (mapping_type == UMAP) */ {
-      Assert((uunmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));;
+      Assert((uunmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
     }
 #endif
   }
@@ -179,7 +178,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
     }
 #else
     else /* if (mapping_type == UMAP) */ {
-      Assert((uunmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));;
+      Assert((uunmap(map, NUMBER_OF_BYTES) == 0), fail_and_close_file(fd, "Unmapping failed: ", errno));
     }
 #endif
     state.ResumeTiming();

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -656,7 +656,6 @@ set(
     lz4
     magic_enum
     sqlparser
-    umap
     uninitialized_vector
     libzstd_static
     ${CMAKE_DL_LIBS}
@@ -664,7 +663,7 @@ set(
 )
 
 if (NOT APPLE)
-    set(LIBRARIES ${LIBRARIES} atomic pthread)
+    set(LIBRARIES ${LIBRARIES} atomic pthread umap)
 endif()
 
 if (${ENABLE_NUMA_SUPPORT})


### PR DESCRIPTION
Our current Master branch does not compile on Mac because UMap is used, which is not available on Mac.
This PR solves this by disabling UMap when Hyrise is compiled on Mac.