### PR TITLE
cache clearing now with sudo

### DIFF
--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <unistd.h>
 #include <fstream>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include <algorithm>
 #include <cstring>
@@ -23,8 +25,11 @@ void micro_benchmark_clear_cache() {
 void micro_benchmark_clear_disk_cache() {
   // TODO(phoenix): better documentation of which caches we are clearing
   sync();
-  std::ofstream ofs("/proc/sys/vm/drop_caches");
-  ofs << "3" << std::endl;
+#ifdef __APPLE__
+  system("purge");
+#else
+  system("echo 3 > /proc/sys/vm/drop_caches");
+#endif
 }
 
 void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes) {


### PR DESCRIPTION
THIS MAKES SUDO RIGHTS MANDATORY TO RUN BENCHMARKS!

After this discussion with Stefan and Martin, we figured out, that we aren't clearing our caches. This should fix it.

See: https://hyrise-db.slack.com/archives/C04G68N1VLK/p1673340099481499
