### PR TITLE
Fix Release build using cache clearing

### DIFF
--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -26,9 +26,11 @@ void micro_benchmark_clear_disk_cache() {
   // TODO(phoenix): better documentation of which caches we are clearing
   sync();
 #ifdef __APPLE__
-  system("purge");
+  auto return_val =  system("purge");
+  (void) return_val;
 #else
-  system("echo 3 > /proc/sys/vm/drop_caches");
+  auto return_val = system("echo 3 > /proc/sys/vm/drop_caches");
+  (void) return_val;
 #endif
 }
 


### PR DESCRIPTION
This is a dirty fix to make the release build work again.

Ideally we Assert a return value to make the value used. But this works for now.