### PR TITLE
[benchmark] Create files once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![Build Status](https://hyrise-ci.epic-hpi.de/buildStatus/icon?job=Hyrise/hyrise/master)](https://hyrise-ci.epic-hpi.de/blue/organizations/jenkins/hyrise%2Fhyrise/activity/)
 [![Coverage Status](https://hyrise-coverage-badge.herokuapp.com/coverage_badge.svg)](https://hyrise-ci.epic-hpi.de/job/Hyrise/job/hyrise/job/master/lastStableBuild/Llvm-cov_5fReport/)
 [![CodeFactor](https://www.codefactor.io/repository/github/hyrise/hyrise/badge)](https://www.codefactor.io/repository/github/hyrise/hyrise)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![Build Status](https://hyrise-ci.epic-hpi.de/buildStatus/icon?job=Hyrise/hyrise/master)](https://hyrise-ci.epic-hpi.de/blue/organizations/jenkins/hyrise%2Fhyrise/activity/)
 [![Coverage Status](https://hyrise-coverage-badge.herokuapp.com/coverage_badge.svg)](https://hyrise-ci.epic-hpi.de/job/Hyrise/job/hyrise/job/master/lastStableBuild/Llvm-cov_5fReport/)
 [![CodeFactor](https://www.codefactor.io/repository/github/hyrise/hyrise/badge)](https://www.codefactor.io/repository/github/hyrise/hyrise)

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -71,7 +71,8 @@ void read_data_using_aio(const size_t from, const size_t to, int32_t fd, uint32_
 
   /* Wait until end of transaction */
   auto err = int{0};
-  while ((err = aio_error(&aiocb)) == EINPROGRESS);
+  while ((err = aio_error(&aiocb)) == EINPROGRESS)
+    ;
 
   aio_error_handling(&aiocb, bytes_to_read);
 }
@@ -94,7 +95,8 @@ void read_data_randomly_using_aio(const size_t from, const size_t to, int32_t fd
 
     /* Wait until end of transaction */
     auto err = int{0};
-    while ((err = aio_error(&aiocb)) == EINPROGRESS);
+    while ((err = aio_error(&aiocb)) == EINPROGRESS)
+      ;
 
     aio_error_handling(&aiocb, uint32_t_size);
   }
@@ -105,7 +107,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto index = size_t{0}; index < thread_count; ++index) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+           close_file_and_return_error_message(fd, "Open error: ", errno));
     filedescriptors[index] = fd;
   }
 
@@ -149,7 +152,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::
 
 void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -177,7 +181,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark:
 
 void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -214,7 +219,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto index = size_t{0}; index < thread_count; ++index) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+           close_file_and_return_error_message(fd, "Open error: ", errno));
     filedescriptors[index] = fd;
   }
 
@@ -236,8 +242,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
       if (to >= NUMBER_OF_ELEMENTS) {
         to = NUMBER_OF_ELEMENTS;
       }
-      threads[index] = (std::thread(read_data_randomly_using_read, from, to, filedescriptors[index], std::data(read_data),
-                                random_indices));
+      threads[index] = (std::thread(read_data_randomly_using_read, from, to, filedescriptors[index],
+                                    std::data(read_data), random_indices));
     }
 
     for (auto index = size_t{0}; index < thread_count; ++index) {
@@ -259,7 +265,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
 
 void FileIOMicroReadBenchmarkFixture::pread_atomic_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -284,7 +291,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_single_threaded(benchmark::St
 
 void FileIOMicroReadBenchmarkFixture::pread_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
@@ -324,7 +332,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_multi_threaded(benchmark::Sta
 
 void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -356,7 +365,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchm
 void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchmark::State& state,
                                                                          uint16_t thread_count) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
@@ -376,7 +386,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
       if (to >= NUMBER_OF_ELEMENTS) {
         to = NUMBER_OF_ELEMENTS;
       }
-      threads[index] = (std::thread(read_data_randomly_using_pread, from, to, fd, std::data(read_data), random_indices));
+      threads[index] =
+          (std::thread(read_data_randomly_using_pread, from, to, fd, std::data(read_data), random_indices));
     }
 
     for (auto index = size_t{0}; index < thread_count; ++index) {
@@ -396,7 +407,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
 
 void FileIOMicroReadBenchmarkFixture::aio_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -419,7 +431,8 @@ void FileIOMicroReadBenchmarkFixture::aio_single_threaded(benchmark::State& stat
 
     /* Wait until end of transaction */
     auto err = int{0};
-    while ((err = aio_error(&aiocb)) == EINPROGRESS);
+    while ((err = aio_error(&aiocb)) == EINPROGRESS)
+      ;
 
     aio_error_handling(&aiocb, NUMBER_OF_BYTES);
 
@@ -435,7 +448,8 @@ void FileIOMicroReadBenchmarkFixture::aio_single_threaded(benchmark::State& stat
 
 void FileIOMicroReadBenchmarkFixture::aio_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
@@ -475,7 +489,8 @@ void FileIOMicroReadBenchmarkFixture::aio_multi_threaded(benchmark::State& state
 
 void FileIOMicroReadBenchmarkFixture::aio_random_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -503,7 +518,8 @@ void FileIOMicroReadBenchmarkFixture::aio_random_single_threaded(benchmark::Stat
 
       /* Wait until end of transaction */
       auto err = int{0};
-      while ((err = aio_error(&aiocb)) == EINPROGRESS);
+      while ((err = aio_error(&aiocb)) == EINPROGRESS)
+        ;
 
       aio_error_handling(&aiocb, uint32_t_size);
     }
@@ -521,7 +537,8 @@ void FileIOMicroReadBenchmarkFixture::aio_random_single_threaded(benchmark::Stat
 
 void FileIOMicroReadBenchmarkFixture::aio_random_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -105,7 +105,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto index = size_t{0}; index < thread_count; ++index) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
     filedescriptors[index] = fd;
   }
 
@@ -149,7 +149,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::
 
 void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -177,7 +177,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark:
 
 void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -214,7 +214,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto index = size_t{0}; index < thread_count; ++index) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
     filedescriptors[index] = fd;
   }
 
@@ -259,7 +259,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
 
 void FileIOMicroReadBenchmarkFixture::pread_atomic_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -284,7 +284,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_single_threaded(benchmark::St
 
 void FileIOMicroReadBenchmarkFixture::pread_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
@@ -324,7 +324,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_multi_threaded(benchmark::Sta
 
 void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -356,7 +356,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchm
 void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchmark::State& state,
                                                                          uint16_t thread_count) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
@@ -396,7 +396,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
 
 void FileIOMicroReadBenchmarkFixture::aio_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -435,7 +435,7 @@ void FileIOMicroReadBenchmarkFixture::aio_single_threaded(benchmark::State& stat
 
 void FileIOMicroReadBenchmarkFixture::aio_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
@@ -475,7 +475,7 @@ void FileIOMicroReadBenchmarkFixture::aio_multi_threaded(benchmark::State& state
 
 void FileIOMicroReadBenchmarkFixture::aio_random_single_threaded(benchmark::State& state) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -521,7 +521,7 @@ void FileIOMicroReadBenchmarkFixture::aio_random_single_threaded(benchmark::Stat
 
 void FileIOMicroReadBenchmarkFixture::aio_random_multi_threaded(benchmark::State& state, uint16_t thread_count) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -1,9 +1,9 @@
 #include <fcntl.h>
-#include <filesystem>
-#include <span>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <filesystem>
 #include <numeric>
+#include <span>
 
 #include "micro_benchmark_basic_fixture.hpp"
 
@@ -12,27 +12,29 @@ namespace hyrise {
 class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
   void SetUp(::benchmark::State& state) override {
-    auto size_parameter = state.range(0);
+    const auto size_parameter = state.range(0);
     NUMBER_OF_BYTES = _align_to_pagesize(size_parameter);
     NUMBER_OF_ELEMENTS = NUMBER_OF_BYTES / uint32_t_size;
-    filename = "benchmark_file_" + std::to_string(size_parameter) + ".txt";
+    filename = "benchmark_data_" + std::to_string(size_parameter) + ".txt";
 
     auto fd = int32_t{};
-    if (!std::filesystem::exists(filename.c_str())) {
-        numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
-        control_sum = std::accumulate(numbers.begin(), numbers.end(), uint64_t{0});
-        Assert(((fd = creat(filename.c_str(), O_WRONLY)) >= 1), close_file_and_return_error_message(fd, "Create error: ", errno));
-        chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
-        Assert((write(fd, std::data(numbers), NUMBER_OF_BYTES) == NUMBER_OF_BYTES),
-               close_file_and_return_error_message(fd, "Write error: ", errno));
-        close(fd);
-    }else{
-        Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
-        auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_PRIVATE, fd, 0));
-        Assert((map != MAP_FAILED), close_file_and_return_error_message(fd, "Mapping Failed: ", errno));
-        auto map_span_view = std::span{map, NUMBER_OF_ELEMENTS};
-        control_sum = std::accumulate(map_span_view.begin(), map_span_view.end(), uint64_t{0});
+    if (!std::filesystem::exists(filename)) {
+      numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
+      control_sum = std::accumulate(numbers.begin(), numbers.end(), uint64_t{0});
+      Assert(((fd = creat(filename.c_str(), O_WRONLY)) >= 1),
+             close_file_and_return_error_message(fd, "Create error: ", errno));
+      chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
+      Assert((write(fd, std::data(numbers), NUMBER_OF_BYTES) == NUMBER_OF_BYTES),
+             close_file_and_return_error_message(fd, "Write error: ", errno));
+    } else {
+      Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+             close_file_and_return_error_message(fd, "Open error: ", errno));
+      const auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_PRIVATE, fd, 0));
+      Assert((map != MAP_FAILED), close_file_and_return_error_message(fd, "Mapping Failed: ", errno));
+      const auto map_span_view = std::span{map, NUMBER_OF_ELEMENTS};
+      control_sum = std::accumulate(map_span_view.begin(), map_span_view.end(), uint64_t{0});
     }
+    close(fd);
   }
 
  protected:
@@ -54,13 +56,16 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void aio_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void aio_random_single_threaded(benchmark::State& state);
   void aio_random_multi_threaded(benchmark::State& state, uint16_t thread_count);
-  void memory_mapped_read_single_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag, const int access_order);
-  void memory_mapped_read_multi_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag, const uint16_t thread_count, const int access_order);
-
+  void memory_mapped_read_single_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag,
+                                          const int access_order);
+  void memory_mapped_read_multi_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag,
+                                         const uint16_t thread_count, const int access_order);
 
   // enums for mmap benchmarks
   enum MAPPING_TYPE { MMAP, UMAP };
+
   enum DATA_ACCESS_TYPES { SEQUENTIAL, RANDOM };
+
   enum MAP_ACCESS_TYPES { SHARED = MAP_SHARED, PRIVATE = MAP_PRIVATE };
 };
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -30,7 +30,8 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
                                                                          const int map_mode_flag,
                                                                          const int access_order) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -101,7 +102,8 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
                                                                         const uint16_t thread_count,
                                                                         const int access_order) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   const auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -30,7 +30,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
                                                                          const int map_mode_flag,
                                                                          const int access_order) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -101,7 +101,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
                                                                         const uint16_t thread_count,
                                                                         const int access_order) {
   auto fd = int32_t{};
-  Assert(((fd = open(filename, O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
   const auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));


### PR DESCRIPTION
Until now, we always created and deleted the benchmark file that we want to read from for each benkmark. It's finally time to change this!