### PR TITLE
[Benchmark] Support 100 GB Benchmarks

### DIFF
--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -101,8 +101,7 @@ void read_data_using_libaio(const size_t thread_from, const size_t thread_to, in
   memset(&ctx, 0, sizeof(ctx));
   io_setup(REQUEST_COUNT, &ctx);
 
-  auto batch_size_thread =
-      static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS_PER_THREAD) / REQUEST_COUNT));
+  const auto batch_size_thread = static_cast<uint64_t>(NUMBER_OF_ELEMENTS_PER_THREAD) / REQUEST_COUNT);
 
   auto iocbs = std::vector<iocb>(REQUEST_COUNT);
   auto iocb_list = std::vector<iocb*>(REQUEST_COUNT);
@@ -318,7 +317,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
   }
 
   auto threads = std::vector<std::thread>(thread_count);
-  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+  const auto batch_size = static_cast<uint64_t>(NUMBER_OF_ELEMENTS / thread_count);
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -408,7 +407,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_multi_threaded(benchmark::Sta
   }
 
   auto threads = std::vector<std::thread>(thread_count);
-  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+  const auto batch_size = static_cast<uint64_t>(NUMBER_OF_ELEMENTS / thread_count);
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -489,7 +488,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
   }
 
   auto threads = std::vector<std::thread>(thread_count);
-  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+  const auto batch_size = static_cast<uint64_t>(NUMBER_OF_ELEMENTS) / thread_count);
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -596,7 +595,7 @@ void FileIOMicroReadBenchmarkFixture::libaio_sequential_read_multi_threaded(benc
   }
 
   auto threads = std::vector<std::thread>(thread_count);
-  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+  const auto batch_size = static_cast<uint64_t>(NUMBER_OF_ELEMENTS / thread_count);
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -639,7 +638,7 @@ void FileIOMicroReadBenchmarkFixture::libaio_random_read(benchmark::State& state
   }
 
   auto threads = std::vector<std::thread>(thread_count);
-  auto batch_size = static_cast<uint64_t>(std::ceil(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count));
+  const auto batch_size = static_cast<uint64_t>(NUMBER_OF_ELEMENTS / thread_count);
 
   for (auto _ : state) {
     state.PauseTiming();

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -216,7 +216,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                 " Expected: " + std::to_string(control_sum) + ".");
     state.ResumeTiming();
   }
 
@@ -261,7 +262,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark:
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                 " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -296,7 +298,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(ben
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                 " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -343,7 +346,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                 " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -387,7 +391,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_single_threaded(benchmark::St
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                 " Expected: " + std::to_string(control_sum) + ".");
     state.ResumeTiming();
   }
 
@@ -431,7 +436,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_multi_threaded(benchmark::Sta
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                 " Expected: " + std::to_string(control_sum) + ".");
     state.ResumeTiming();
   }
 
@@ -464,7 +470,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchm
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                 " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -509,7 +516,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                 " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -569,7 +577,8 @@ void FileIOMicroReadBenchmarkFixture::libaio_sequential_read_single_threaded(ben
 
     state.PauseTiming();
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                                   " Expected: " + std::to_string(control_sum) + ".");
     state.ResumeTiming();
   }
 
@@ -734,7 +743,8 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(b
     state.PauseTiming();
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
 
-    Assert(control_sum == sum, "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                           " Expected: " + std::to_string(control_sum) + ".");
     Assert(&read_data != &numbers, "Sanity check failed: Same reference");
 
     state.ResumeTiming();
@@ -756,7 +766,8 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
     state.PauseTiming();
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
 
-    Assert(control_sum == static_cast<uint64_t>(sum), "Sanity check failed: Not the same result");
+    Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
+                           " Expected: " + std::to_string(control_sum) + ".");
     Assert(&read_data[0] != &numbers[random_indices[0]], "Sanity check failed: Same reference");
 
     state.ResumeTiming();

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -765,7 +765,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -22,24 +22,24 @@ void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32
   const auto elements_to_read = static_cast<uint64_t>(total_bytes_to_read / uint32_t_size);
   const auto MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
 
-
-  if(elements_to_read > MAX_NUMBER_OF_ELEMENTS){
-      auto elements_read = uint64_t {0};
-      auto elements_remaining = elements_to_read;
-      while (elements_remaining > 0) {
-          lseek(fd, (from + elements_read) * uint32_t_size, SEEK_SET);
-          auto elements_to_read_this_iteration = std::min(elements_remaining, MAX_NUMBER_OF_ELEMENTS);
-          auto bytes_to_read = elements_to_read_this_iteration * uint32_t_size;
-          auto bytes_read_this_iteration = static_cast<size_t>(read(fd, read_data_start + from + elements_read, bytes_to_read));
-          Assert((bytes_read_this_iteration == bytes_to_read),
-                 close_file_and_return_error_message(fd, "Read error: ", errno));
-          elements_read += elements_to_read_this_iteration;
-          elements_remaining -= elements_to_read_this_iteration;
-      }
-  }else{
-      lseek(fd, from * uint32_t_size, SEEK_SET);
-      Assert((read(fd, read_data_start + from, total_bytes_to_read) == total_bytes_to_read),
+  if (elements_to_read > MAX_NUMBER_OF_ELEMENTS) {
+    auto elements_read = uint64_t{0};
+    auto elements_remaining = elements_to_read;
+    while (elements_remaining > 0) {
+      lseek(fd, (from + elements_read) * uint32_t_size, SEEK_SET);
+      auto elements_to_read_this_iteration = std::min(elements_remaining, MAX_NUMBER_OF_ELEMENTS);
+      auto bytes_to_read = elements_to_read_this_iteration * uint32_t_size;
+      auto bytes_read_this_iteration =
+          static_cast<size_t>(read(fd, read_data_start + from + elements_read, bytes_to_read));
+      Assert((bytes_read_this_iteration == bytes_to_read),
              close_file_and_return_error_message(fd, "Read error: ", errno));
+      elements_read += elements_to_read_this_iteration;
+      elements_remaining -= elements_to_read_this_iteration;
+    }
+  } else {
+    lseek(fd, from * uint32_t_size, SEEK_SET);
+    Assert((read(fd, read_data_start + from, total_bytes_to_read) == total_bytes_to_read),
+           close_file_and_return_error_message(fd, "Read error: ", errno));
   }
 }
 
@@ -57,26 +57,27 @@ void read_data_randomly_using_read(const size_t from, const size_t to, int32_t f
 }
 
 void read_data_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start) {
-    const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
-    const auto total_bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
-    const auto elements_to_read = static_cast<uint64_t>(total_bytes_to_read / uint32_t_size);
-    const auto MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
-    if(elements_to_read > MAX_NUMBER_OF_ELEMENTS){
-        auto elements_read = uint64_t {0};
-        auto elements_remaining = elements_to_read;
-        while (elements_remaining > 0) {
-            auto elements_to_read_this_iteration = std::min(elements_remaining, MAX_NUMBER_OF_ELEMENTS);
-            auto bytes_to_read = elements_to_read_this_iteration * uint32_t_size;
-            auto bytes_read_this_iteration = static_cast<size_t>(pread(fd, read_data_start + from + elements_read, bytes_to_read, (from + elements_read) * uint32_t_size));
-            Assert((bytes_read_this_iteration == bytes_to_read),
-                   close_file_and_return_error_message(fd, "Read error: ", errno));
-            elements_read += elements_to_read_this_iteration;
-            elements_remaining -= elements_to_read_this_iteration;
-        }
-    }else{
-        Assert((pread(fd, read_data_start + from, total_bytes_to_read, from * uint32_t_size) == total_bytes_to_read),
-               close_file_and_return_error_message(fd, "Read error: ", errno));
+  const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const auto total_bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
+  const auto elements_to_read = static_cast<uint64_t>(total_bytes_to_read / uint32_t_size);
+  const auto MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
+  if (elements_to_read > MAX_NUMBER_OF_ELEMENTS) {
+    auto elements_read = uint64_t{0};
+    auto elements_remaining = elements_to_read;
+    while (elements_remaining > 0) {
+      auto elements_to_read_this_iteration = std::min(elements_remaining, MAX_NUMBER_OF_ELEMENTS);
+      auto bytes_to_read = elements_to_read_this_iteration * uint32_t_size;
+      auto bytes_read_this_iteration = static_cast<size_t>(
+          pread(fd, read_data_start + from + elements_read, bytes_to_read, (from + elements_read) * uint32_t_size));
+      Assert((bytes_read_this_iteration == bytes_to_read),
+             close_file_and_return_error_message(fd, "Read error: ", errno));
+      elements_read += elements_to_read_this_iteration;
+      elements_remaining -= elements_to_read_this_iteration;
     }
+  } else {
+    Assert((pread(fd, read_data_start + from, total_bytes_to_read, from * uint32_t_size) == total_bytes_to_read),
+           close_file_and_return_error_message(fd, "Read error: ", errno));
+  }
 }
 
 void read_data_randomly_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start,
@@ -217,7 +218,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_multi_threaded(benchmark::
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
     state.ResumeTiming();
   }
 
@@ -240,30 +241,30 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_single_threaded(benchmark:
 
     state.ResumeTiming();
 
-      if(NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS){
-          auto elements_read = uint64_t {0};
-          auto elements_remaining = NUMBER_OF_ELEMENTS;
-          auto read_data_start = std::data(read_data);
-          while (elements_remaining > 0) {
-              auto elements_to_read_this_iteration = std::min(elements_remaining, MAX_NUMBER_OF_ELEMENTS);
-              auto bytes_to_read = elements_to_read_this_iteration * uint32_t_size;
-              auto bytes_read_this_iteration = static_cast<size_t>(read(fd, read_data_start + elements_read, bytes_to_read));
-              Assert((bytes_read_this_iteration == bytes_to_read),
-                     close_file_and_return_error_message(fd, "Read error: ", errno));
-              elements_read += elements_to_read_this_iteration;
-              elements_remaining -= elements_to_read_this_iteration;
-          }
-      }else{
-          lseek(fd, 0, SEEK_SET);
-          Assert((static_cast<uint64_t>(read(fd, std::data(read_data), NUMBER_OF_BYTES)) == NUMBER_OF_BYTES),
-                 close_file_and_return_error_message(fd, "Read error: ", errno));
+    if (NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS) {
+      auto elements_read = uint64_t{0};
+      auto elements_remaining = NUMBER_OF_ELEMENTS;
+      auto read_data_start = std::data(read_data);
+      while (elements_remaining > 0) {
+        auto elements_to_read_this_iteration = std::min(elements_remaining, MAX_NUMBER_OF_ELEMENTS);
+        auto bytes_to_read = elements_to_read_this_iteration * uint32_t_size;
+        auto bytes_read_this_iteration = static_cast<size_t>(read(fd, read_data_start + elements_read, bytes_to_read));
+        Assert((bytes_read_this_iteration == bytes_to_read),
+               close_file_and_return_error_message(fd, "Read error: ", errno));
+        elements_read += elements_to_read_this_iteration;
+        elements_remaining -= elements_to_read_this_iteration;
       }
+    } else {
+      lseek(fd, 0, SEEK_SET);
+      Assert((static_cast<uint64_t>(read(fd, std::data(read_data), NUMBER_OF_BYTES)) == NUMBER_OF_BYTES),
+             close_file_and_return_error_message(fd, "Read error: ", errno));
+    }
 
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -299,7 +300,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(ben
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -336,7 +337,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
         to = NUMBER_OF_ELEMENTS;
       }
       threads[index] = (std::thread(read_data_randomly_using_read, from, to, filedescriptors[index],
-                                    std::data(read_data), random_indices));
+                                    std::data(read_data), std::ref(random_indices)));
     }
 
     for (auto index = size_t{0}; index < thread_count; ++index) {
@@ -347,7 +348,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -370,29 +371,30 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_single_threaded(benchmark::St
     read_data.resize(NUMBER_OF_ELEMENTS);
     state.ResumeTiming();
 
-    if(NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS){
-        auto elements_read = uint64_t {0};
-        auto elements_remaining = NUMBER_OF_ELEMENTS;
-        auto read_data_start = std::data(read_data);
-        while (elements_remaining > 0) {
-            auto elements_to_read_this_iteration = std::min(elements_remaining, MAX_NUMBER_OF_ELEMENTS);
-            auto bytes_to_read = elements_to_read_this_iteration * uint32_t_size;
-            auto bytes_read_this_iteration = static_cast<size_t>(pread(fd, read_data_start + elements_read, bytes_to_read, elements_read * uint32_t_size));
-            Assert((bytes_read_this_iteration == bytes_to_read),
-                   close_file_and_return_error_message(fd, "Read error: ", errno));
-            elements_read += elements_to_read_this_iteration;
-            elements_remaining -= elements_to_read_this_iteration;
-        }
-    }else{
-        Assert((static_cast<uint64_t>(pread(fd, std::data(read_data), NUMBER_OF_BYTES, 0)) == NUMBER_OF_BYTES),
+    if (NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS) {
+      auto elements_read = uint64_t{0};
+      auto elements_remaining = NUMBER_OF_ELEMENTS;
+      auto read_data_start = std::data(read_data);
+      while (elements_remaining > 0) {
+        auto elements_to_read_this_iteration = std::min(elements_remaining, MAX_NUMBER_OF_ELEMENTS);
+        auto bytes_to_read = elements_to_read_this_iteration * uint32_t_size;
+        auto bytes_read_this_iteration = static_cast<size_t>(
+            pread(fd, read_data_start + elements_read, bytes_to_read, elements_read * uint32_t_size));
+        Assert((bytes_read_this_iteration == bytes_to_read),
                close_file_and_return_error_message(fd, "Read error: ", errno));
+        elements_read += elements_to_read_this_iteration;
+        elements_remaining -= elements_to_read_this_iteration;
+      }
+    } else {
+      Assert((static_cast<uint64_t>(pread(fd, std::data(read_data), NUMBER_OF_BYTES, 0)) == NUMBER_OF_BYTES),
+             close_file_and_return_error_message(fd, "Read error: ", errno));
     }
 
     state.PauseTiming();
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
     state.ResumeTiming();
   }
 
@@ -403,7 +405,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_multi_threaded(benchmark::Sta
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto index = size_t{0}; index < thread_count; ++index) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+           close_file_and_return_error_message(fd, "Open error: ", errno));
     filedescriptors[index] = fd;
   }
 
@@ -437,7 +440,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_multi_threaded(benchmark::Sta
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
     state.ResumeTiming();
   }
 
@@ -471,7 +474,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchm
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -484,7 +487,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto index = size_t{0}; index < thread_count; ++index) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+           close_file_and_return_error_message(fd, "Open error: ", errno));
     filedescriptors[index] = fd;
   }
 
@@ -506,7 +510,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
       if (to + batch_size >= NUMBER_OF_ELEMENTS) {
         to = NUMBER_OF_ELEMENTS;
       }
-      threads[index] = (std::thread(read_data_randomly_using_pread, from, to, filedescriptors[index], std::data(read_data), random_indices));
+      threads[index] = (std::thread(read_data_randomly_using_pread, from, to, filedescriptors[index],
+                                    std::data(read_data), std::ref(random_indices)));
     }
 
     for (auto index = size_t{0}; index < thread_count; ++index) {
@@ -517,7 +522,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
 
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
 
     state.ResumeTiming();
   }
@@ -591,7 +596,8 @@ void FileIOMicroReadBenchmarkFixture::libaio_sequential_read_multi_threaded(benc
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto index = size_t{0}; index < thread_count; ++index) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+           close_file_and_return_error_message(fd, "Open error: ", errno));
     filedescriptors[index] = fd;
   }
 
@@ -634,7 +640,8 @@ void FileIOMicroReadBenchmarkFixture::libaio_random_read(benchmark::State& state
   auto filedescriptors = std::vector<int32_t>(thread_count);
   for (auto index = size_t{0}; index < thread_count; ++index) {
     auto fd = int32_t{};
-    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+           close_file_and_return_error_message(fd, "Open error: ", errno));
     filedescriptors[index] = fd;
   }
 
@@ -656,7 +663,7 @@ void FileIOMicroReadBenchmarkFixture::libaio_random_read(benchmark::State& state
         to = NUMBER_OF_ELEMENTS;
       }
       threads[index] = (std::thread(read_data_randomly_using_libaio, from, to, filedescriptors[index],
-                                    std::data(read_data), random_indices));
+                                    std::data(read_data), std::ref(random_indices)));
     }
 
     for (auto index = size_t{0}; index < thread_count; ++index) {
@@ -744,7 +751,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(b
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
 
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                           " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
     Assert(&read_data != &numbers, "Sanity check failed: Same reference");
 
     state.ResumeTiming();
@@ -767,7 +774,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
     const auto sum = std::accumulate(read_data.begin(), read_data.end(), uint64_t{0});
 
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
-                           " Expected: " + std::to_string(control_sum) + ".");
+                                   " Expected: " + std::to_string(control_sum) + ".");
     Assert(&read_data[0] != &numbers[random_indices[0]], "Sanity check failed: Same reference");
 
     state.ResumeTiming();
@@ -775,30 +782,29 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
+
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
-
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
-
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 #endif
 /*

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -830,20 +830,22 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
+
+/*
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->ArgsProduct({{10, 100, 1000}, {1, 2, 8, 24, 56, 64}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->ArgsProduct({{10, 100, 1000}, {1, 2, 8, 24, 56, 64}, {0}})
     ->UseRealTime();
-
+*/
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->ArgsProduct({{10, 100, 1000}, {1, 2, 8, 24, 56, 64}, {1}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->ArgsProduct({{10, 100, 1000}, {1, 2, 8, 24, 56, 64}, {1}})
     ->UseRealTime();
 
 #ifdef __linux__

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -757,9 +757,9 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 24, 32}})
     ->UseRealTime();
-
+/*
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
     ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
     ->UseRealTime();
@@ -785,5 +785,5 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(1000)->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(1000)->UseRealTime();
-
+*/
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -16,11 +16,6 @@
 
 namespace hyrise {
 
-void print_execution_time(const std::chrono::time_point<std::chrono::high_resolution_clock> start, const size_t from) {
-  auto stop = std::chrono::high_resolution_clock::now();
-  std::cout << "From: " << std::to_string(from) << " Start: " << start.time_since_epoch().count()
-            << " Stop: " << stop.time_since_epoch().count() << std::endl;
-}
 
 void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start,
                           std::atomic<bool>& threads_ready_to_be_executed, std::atomic<bool>& verbose) {

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -281,7 +281,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(ben
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    const auto random_indices = random_indexes_map[state.range(0)];
+    //const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
 
@@ -325,7 +326,8 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    const auto random_indices = random_indexes_map[state.range(0)];
+    //const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
 
@@ -457,7 +459,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchm
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    const auto random_indices = random_indexes_map[state.range(0)];
+    //const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
 
@@ -499,7 +502,8 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    const auto random_indices = random_indexes_map[state.range(0)];
+    // const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
 
@@ -651,7 +655,8 @@ void FileIOMicroReadBenchmarkFixture::libaio_random_read(benchmark::State& state
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    const auto random_indices = random_indexes_map[state.range(0)];
+    //const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
     state.ResumeTiming();
@@ -761,7 +766,9 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(b
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
-    const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
+    const auto random_indices = random_indexes_map[state.range(0)];
+
+    // const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
     state.ResumeTiming();
@@ -782,7 +789,6 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 }
 
 // Arguments are file size in MB
-
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -765,29 +765,29 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 #endif
 /*

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -20,7 +20,8 @@ void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
   const auto total_bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
   const auto elements_to_read = static_cast<uint64_t>(total_bytes_to_read / uint32_t_size);
-  const auto MAX_NUMBER_OF_ELEMENTS = uint64_t{250000384};
+  const auto MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
+
 
   if(elements_to_read > MAX_NUMBER_OF_ELEMENTS){
       auto elements_read = uint64_t {0};
@@ -59,7 +60,7 @@ void read_data_using_pread(const size_t from, const size_t to, int32_t fd, uint3
     const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
     const auto total_bytes_to_read = static_cast<ssize_t>(uint32_t_size * (to - from));
     const auto elements_to_read = static_cast<uint64_t>(total_bytes_to_read / uint32_t_size);
-    const auto MAX_NUMBER_OF_ELEMENTS = uint64_t{250000384};
+    const auto MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
     if(elements_to_read > MAX_NUMBER_OF_ELEMENTS){
         auto elements_read = uint64_t {0};
         auto elements_remaining = elements_to_read;

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -101,7 +101,7 @@ void read_data_using_libaio(const size_t thread_from, const size_t thread_to, in
   memset(&ctx, 0, sizeof(ctx));
   io_setup(REQUEST_COUNT, &ctx);
 
-  const auto batch_size_thread = static_cast<uint64_t>(NUMBER_OF_ELEMENTS_PER_THREAD) / REQUEST_COUNT);
+  const auto batch_size_thread = static_cast<uint64_t>(NUMBER_OF_ELEMENTS_PER_THREAD / REQUEST_COUNT);
 
   auto iocbs = std::vector<iocb>(REQUEST_COUNT);
   auto iocb_list = std::vector<iocb*>(REQUEST_COUNT);

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -698,8 +698,6 @@ void FileIOMicroReadBenchmarkFixture::libaio_random_read(benchmark::State& state
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = random_indexes_map[state.range(0)];
-    //const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
     state.ResumeTiming();
@@ -711,7 +709,7 @@ void FileIOMicroReadBenchmarkFixture::libaio_random_read(benchmark::State& state
         to = NUMBER_OF_ELEMENTS;
       }
       threads[index] = (std::thread(read_data_randomly_using_libaio, from, to, filedescriptors[index],
-                                    std::data(read_data), std::ref(random_indices)));
+                                    std::data(read_data), std::ref(random_indexes)));
     }
 
     for (auto index = size_t{0}; index < thread_count; ++index) {
@@ -833,13 +831,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->ArgsProduct({{100000}, {1, 2, 4, 8}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->ArgsProduct({{100000}, {1, 2, 4, 8}, {1}})
     ->UseRealTime();
-
+/*
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
@@ -856,7 +854,7 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 #endif
-/*
+
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(1000)->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(1000)->UseRealTime();
 */

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -835,7 +835,7 @@ static void CustomArguments(benchmark::internal::Benchmark* benchmark) {
       benchmark->Args({parameters[param_index], thread_counts[thread_index]});
 }
 
-/*
+
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
     ->Apply(CustomArguments)
     ->UseRealTime();
@@ -843,7 +843,7 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
     ->Apply(CustomArguments)
     ->UseRealTime();
-*/
+
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
     ->Apply(CustomArguments)
     ->UseRealTime();
@@ -858,7 +858,7 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_SEQUENTIAL_THREADED
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)->Apply(CustomArguments)->UseRealTime();
 #endif
-/*
+/
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(1000)->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(1000)->UseRealTime();
 */

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -693,8 +693,9 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10, 100, 1000, 10000, 100000}, {2}})
     ->UseRealTime();
+/*
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
     ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32, 48}})
     ->UseRealTime();
@@ -715,5 +716,5 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)
 #endif
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(1000)->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(1000)->UseRealTime();
-
+*/
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -488,7 +488,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
   }
 
   auto threads = std::vector<std::thread>(thread_count);
-  const auto batch_size = static_cast<uint64_t>(NUMBER_OF_ELEMENTS) / thread_count);
+  const auto batch_size = static_cast<uint64_t>(NUMBER_OF_ELEMENTS / thread_count);
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -735,7 +735,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(b
 
     state.ResumeTiming();
 
-    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+    for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
       read_data[index] = numbers[index];
     }
 

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -765,32 +765,32 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 24, 32}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
-/*
+
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 #endif
-
+/*
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(1000)->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(1000)->UseRealTime();
 */

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -317,7 +317,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(ben
     state.PauseTiming();
 
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = random_indexes_map[state.range(0)];
+    //const auto random_indices = random_indexes_map[state.range(0)];
     //const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
@@ -328,7 +328,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(ben
     // TODO(everyone): Randomize inidzes to not read all the data but really randomize the reads to read same amount but
     //  incl possible duplicates
     for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
-      lseek(fd, uint32_t_size * random_indices[index], SEEK_SET);
+      lseek(fd, uint32_t_size * random_indexes[index], SEEK_SET);
       Assert((read(fd, std::data(read_data) + index, uint32_t_size) == uint32_t_size),
              close_file_and_return_error_message(fd, "Read error: ", errno));
     }
@@ -363,7 +363,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
 
     std::atomic<bool> threads_ready_to_be_executed = false;
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = random_indexes_map[state.range(0)];
+    //const auto random_indices = random_indexes_map[state.range(0)];
     //const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
@@ -376,7 +376,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_multi_threaded(benc
       }
       threads[index] =
           (std::thread(read_data_randomly_using_read, from, to, filedescriptors[index], std::data(read_data),
-                       std::ref(random_indices), std::ref(threads_ready_to_be_executed), std::ref(verbose)));
+                       std::ref(random_indexes), std::ref(threads_ready_to_be_executed), std::ref(verbose)));
     }
 
     state.ResumeTiming();
@@ -500,7 +500,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchm
   for (auto _ : state) {
     state.PauseTiming();
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = random_indexes_map[state.range(0)];
+    // const auto random_indices = random_indexes_map[state.range(0)];
     //const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
@@ -509,7 +509,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchm
 
     // TODO(everyone) Randomize inidzes to not read all the data but really randomize
     for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
-      Assert((pread(fd, std::data(read_data) + index, uint32_t_size, uint32_t_size * random_indices[index]) ==
+      Assert((pread(fd, std::data(read_data) + index, uint32_t_size, uint32_t_size * random_indexes[index]) ==
               uint32_t_size),
              close_file_and_return_error_message(fd, "Read error: ", errno));
     }
@@ -543,7 +543,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
     state.PauseTiming();
     std::atomic<bool> threads_ready_to_be_executed = false;
     micro_benchmark_clear_disk_cache();
-    const auto random_indices = random_indexes_map[state.range(0)];
+    //const auto random_indices = random_indexes_map[state.range(0)];
     // const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
     read_data.resize(NUMBER_OF_ELEMENTS);
@@ -556,7 +556,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_multi_threaded(benchma
       }
       threads[index] =
           (std::thread(read_data_randomly_using_pread, from, to, filedescriptors[index], std::data(read_data),
-                       std::ref(random_indices), std::ref(threads_ready_to_be_executed), std::ref(verbose)));
+                       std::ref(random_indexes), std::ref(threads_ready_to_be_executed), std::ref(verbose)));
     }
 
     state.ResumeTiming();
@@ -809,7 +809,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)(b
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
-    const auto random_indices = random_indexes_map[state.range(0)];
+    //const auto random_indices = random_indexes_map[state.range(0)];
 
     // const auto random_indices = generate_random_indexes(NUMBER_OF_ELEMENTS);
     auto read_data = std::vector<uint32_t>{};
@@ -817,7 +817,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
     state.ResumeTiming();
 
     for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
-      read_data[index] = numbers[random_indices[index]];
+      read_data[index] = numbers[random_indexes[index]];
     }
 
     state.PauseTiming();
@@ -825,7 +825,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
     Assert(control_sum == sum, "Sanity check failed: Not the same result. Got: " + std::to_string(sum) +
                                    " Expected: " + std::to_string(control_sum) + ".");
-    Assert(&read_data[0] != &numbers[random_indices[0]], "Sanity check failed: Same reference");
+    Assert(&read_data[0] != &numbers[random_indexes[0]], "Sanity check failed: Same reference");
 
     state.ResumeTiming();
   }
@@ -833,27 +833,27 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 #endif
 /*

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -831,15 +831,15 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-        ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
-        ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -831,13 +831,13 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{100000}, {1, 2, 4, 8}, {0}})
+        ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)
-    ->ArgsProduct({{100000}, {1, 2, 4, 8}, {1}})
+        ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
-/*
+
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_SEQUENTIAL_THREADED)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
@@ -854,7 +854,7 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 #endif
-
+/*
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(1000)->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(1000)->UseRealTime();
 */

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -829,15 +829,15 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THR
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, PREAD_ATOMIC_RANDOM_THREADED)
     ->Apply(CustomArguments)
     ->UseRealTime();
-
+/*
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_SEQUENTIAL_THREADED)
     ->Apply(CustomArguments)
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, LIBAIO_RANDOM_THREADED)->Apply(CustomArguments)->UseRealTime();
 #endif
-
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(1000)->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(1000)->UseRealTime();
+*/
+//BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_SEQUENTIAL)->Arg(1000)->UseRealTime();
+//BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)->Arg(1000)->UseRealTime();
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -765,7 +765,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
 
 // Arguments are file size in MB
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_SEQUENTIAL_THREADED)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, READ_NON_ATOMIC_RANDOM_THREADED)

--- a/src/benchmark/file_io_read_micro_benchmark.cpp
+++ b/src/benchmark/file_io_read_micro_benchmark.cpp
@@ -43,7 +43,7 @@ void read_data_using_read(const size_t from, const size_t to, int32_t fd, uint32
 }
 
 void read_data_randomly_using_read(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start,
-                                   const std::vector<uint32_t>& random_indices) {
+                                   const std::vector<uint64_t>& random_indices) {
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
 
   // TODO(everyone): Randomize inidzes to not read all the data but really randomize the reads to read same amount but
@@ -79,7 +79,7 @@ void read_data_using_pread(const size_t from, const size_t to, int32_t fd, uint3
 }
 
 void read_data_randomly_using_pread(const size_t from, const size_t to, int32_t fd, uint32_t* read_data_start,
-                                    const std::vector<uint32_t>& random_indices) {
+                                    const std::vector<uint64_t>& random_indices) {
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
 
   lseek(fd, 0, SEEK_SET);
@@ -132,7 +132,7 @@ void read_data_using_libaio(const size_t thread_from, const size_t thread_to, in
 }
 
 void read_data_randomly_using_libaio(const size_t thread_from, const size_t thread_to, int32_t fd,
-                                     uint32_t* read_data_start, const std::vector<uint32_t>& random_indices) {
+                                     uint32_t* read_data_start, const std::vector<uint64_t>& random_indices) {
   const auto uint32_t_size = ssize_t{sizeof(uint32_t)};
   const auto REQUEST_COUNT = uint32_t{64};
   const auto NUMBER_OF_ELEMENTS_PER_THREAD = (thread_to - thread_from);
@@ -289,7 +289,7 @@ void FileIOMicroReadBenchmarkFixture::read_non_atomic_random_single_threaded(ben
     lseek(fd, 0, SEEK_SET);
     // TODO(everyone): Randomize inidzes to not read all the data but really randomize the reads to read same amount but
     //  incl possible duplicates
-    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+    for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
       lseek(fd, uint32_t_size * random_indices[index], SEEK_SET);
       Assert((read(fd, std::data(read_data) + index, uint32_t_size) == uint32_t_size),
              close_file_and_return_error_message(fd, "Read error: ", errno));
@@ -461,7 +461,7 @@ void FileIOMicroReadBenchmarkFixture::pread_atomic_random_single_threaded(benchm
     state.ResumeTiming();
 
     // TODO(everyone) Randomize inidzes to not read all the data but really randomize
-    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+    for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
       Assert((pread(fd, std::data(read_data) + index, uint32_t_size, uint32_t_size * random_indices[index]) ==
               uint32_t_size),
              close_file_and_return_error_message(fd, "Read error: ", errno));
@@ -759,7 +759,7 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, IN_MEMORY_READ_RANDOM)(bench
     read_data.resize(NUMBER_OF_ELEMENTS);
     state.ResumeTiming();
 
-    for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+    for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
       read_data[index] = numbers[random_indices[index]];
     }
 

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -48,16 +48,16 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
       if(NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS){
           auto original_file = "benchmark_data_1000.txt";
           create_large_file(original_file, filename, static_cast<uint32_t>(size_parameter/1000));
+          chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
       }else{
           numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
           Assert(((fd = creat(filename.c_str(), O_WRONLY)) >= 1),
                  close_file_and_return_error_message(fd, "Create error: ", errno));
-
+          chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
           Assert((static_cast<uint64_t>(write(fd, std::data(numbers), NUMBER_OF_BYTES)) == NUMBER_OF_BYTES),
                  close_file_and_return_error_message(fd, "Write error: ", errno));
       }
     }
-  chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
   Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
          close_file_and_return_error_message(fd, "Open error: ", errno));
   const auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_PRIVATE, fd, 0));

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -84,6 +84,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   // MAX_NUMBER_OF_ELEMENTS = max. read/write according to man page / uint32_t_size
   // = 2,147,479,552 bytes / 4 bytes = 536,869,888
   const uint64_t MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
+  std::atomic<bool> verbose = true;
   std::string filename;
   uint64_t control_sum = uint64_t{0};
   uint64_t NUMBER_OF_BYTES = uint64_t{0};

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -71,8 +71,8 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  protected:
   const ssize_t uint32_t_size = ssize_t{sizeof(uint32_t)};
   // MAX_NUMBER_OF_ELEMENTS = max. read/write according to man page / uint32_t_size
-  // = 2,147,479,552 bytes / 4 bytes = 536869888
-  const uint64_t MAX_NUMBER_OF_ELEMENTS = uint64_t{536869888};
+  // = 2,147,479,552 bytes / 4 bytes = 536,869,888
+  const uint64_t MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
   std::string filename;
   uint64_t control_sum = uint64_t{0};
   uint64_t NUMBER_OF_BYTES = uint64_t{0};

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -48,26 +48,24 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
       if(NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS){
           auto original_file = "benchmark_data_1000.txt";
           create_large_file(original_file, filename, static_cast<uint32_t>(size_parameter/1000));
-          chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
       }else{
           numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
-          control_sum = std::accumulate(numbers.begin(), numbers.end(), uint64_t{0});
-
           Assert(((fd = creat(filename.c_str(), O_WRONLY)) >= 1),
                  close_file_and_return_error_message(fd, "Create error: ", errno));
-          chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
+
           Assert((static_cast<uint64_t>(write(fd, std::data(numbers), NUMBER_OF_BYTES)) == NUMBER_OF_BYTES),
                  close_file_and_return_error_message(fd, "Write error: ", errno));
       }
-    } else {
-      Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
-             close_file_and_return_error_message(fd, "Open error: ", errno));
-      const auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_PRIVATE, fd, 0));
-      Assert((map != MAP_FAILED), close_file_and_return_error_message(fd, "Mapping Failed: ", errno));
-      const auto map_span_view = std::span{map, NUMBER_OF_ELEMENTS};
-      control_sum = std::accumulate(map_span_view.begin(), map_span_view.end(), uint64_t{0});
     }
-    close(fd);
+  chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
+  const auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_PRIVATE, fd, 0));
+  Assert((map != MAP_FAILED), close_file_and_return_error_message(fd, "Mapping Failed: ", errno));
+  const auto map_span_view = std::span{map, NUMBER_OF_ELEMENTS};
+  control_sum = std::accumulate(map_span_view.begin(), map_span_view.end(), uint64_t{0});
+
+  close(fd);
   }
 
  protected:

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -42,8 +42,13 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
 
   void create_random_indexes_if_not_exist(size_t size_parameter, uint64_t number_of_elements) {
     if (random_indexes.size() == 0) {
+        const auto start = std::chrono::high_resolution_clock::now();
+
       std::cout << "Creating random_indexes for: " << size_parameter << std::endl;
       random_indexes = generate_random_indexes(number_of_elements);
+      const auto stop = std::chrono::high_resolution_clock::now();
+      const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(stop - start);
+      std::cout << "Elapes seconds: " << elapsed.count() <<  std::endl;
     }
   }
 

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -48,6 +48,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
       if(NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS){
           auto original_file = "benchmark_data_1000.txt";
           create_large_file(original_file, filename, static_cast<uint32_t>(size_parameter/1000));
+          chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
       }else{
           numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
           control_sum = std::accumulate(numbers.begin(), numbers.end(), uint64_t{0});

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -41,10 +41,9 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   }
 
   void create_random_indexes_if_not_exist(size_t size_parameter, uint64_t number_of_elements) {
-    if (random_indexes_map.find(size_parameter) == random_indexes_map.end()) {
+    if (random_indexes.size() == 0) {
       std::cout << "Creating random_indexes for: " << size_parameter << std::endl;
-      const auto indexes = generate_random_indexes(number_of_elements);
-      random_indexes_map[size_parameter] = indexes;
+      random_indexes = generate_random_indexes(number_of_elements);
     }
   }
 
@@ -52,7 +51,10 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
     const auto size_parameter = state.range(0);
     NUMBER_OF_BYTES = _align_to_pagesize(size_parameter);
     NUMBER_OF_ELEMENTS = NUMBER_OF_BYTES / uint32_t_size;
-    create_random_indexes_if_not_exist(size_parameter, NUMBER_OF_ELEMENTS);
+
+    const auto ACCESS_TYPE = state.range(2);
+    if (ACCESS_TYPE != 0)
+      create_random_indexes_if_not_exist(size_parameter, NUMBER_OF_ELEMENTS);
     filename = "benchmark_data_" + std::to_string(size_parameter) + ".txt";
 
     auto fd = int32_t{};
@@ -90,7 +92,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   uint64_t NUMBER_OF_BYTES = uint64_t{0};
   uint64_t NUMBER_OF_ELEMENTS = uint64_t{0};
   std::vector<uint32_t> numbers = std::vector<uint32_t>{};
-  std::map<size_t, std::vector<uint64_t>> random_indexes_map = std::map<size_t, std::vector<uint64_t>>{};
+  std::vector<uint64_t> random_indexes = std::vector<uint64_t>{};
   void read_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void read_non_atomic_single_threaded(benchmark::State& state);
   void read_non_atomic_random_multi_threaded(benchmark::State& state, uint16_t thread_count);

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -19,14 +19,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
   void create_random_indexes_if_needed(size_t size_parameter, uint64_t number_of_elements) {
     if (random_indexes.empty() || last_size_parameter != size_parameter) {
-      const auto start = std::chrono::high_resolution_clock::now();
-      if (verbose)
-        std::cout << "Creating random_indexes for: " << size_parameter << std::endl;
       random_indexes = generate_random_indexes(number_of_elements);
-      const auto stop = std::chrono::high_resolution_clock::now();
-      const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(stop - start);
-      if (verbose)
-        std::cout << "Elapsed seconds: " << elapsed.count() << std::endl;
       last_size_parameter = size_parameter;
     }
   }
@@ -53,10 +46,8 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
 
  protected:
   const ssize_t uint32_t_size = ssize_t{sizeof(uint32_t)};
-  // MAX_NUMBER_OF_ELEMENTS = max. read/write according to man page / uint32_t_size
-  // = 2,147,479,552 bytes / 4 bytes = 536,869,888
+  // read / write accept at most up to = 2,147,479,552 bytes
   const uint64_t MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
-  std::atomic<bool> verbose = false;
   std::string filename;
   uint64_t control_sum = uint64_t{0};
   uint64_t NUMBER_OF_BYTES = uint64_t{0};

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -1,9 +1,9 @@
 #include <fcntl.h>
-#include <iostream>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <numeric>
 #include <span>
 
@@ -13,29 +13,28 @@ namespace hyrise {
 
 class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
+  void create_large_file(std::string original_file_name, std::string copied_file_name, size_t scale_factor) {
+    std::ifstream source(original_file_name, std::ios::binary);
+    std::ofstream destination(copied_file_name, std::ios::binary);
 
-    void create_large_file(std::string original_file_name, std::string copied_file_name, size_t scale_factor){
-        std::ifstream source(original_file_name, std::ios::binary);
-        std::ofstream destination(copied_file_name, std::ios::binary);
+    if (source.is_open() && destination.is_open()) {
+      // Create a buffer to hold the contents of the original file
+      std::vector<char> buffer(std::istreambuf_iterator<char>(source), {});
 
-        if (source.is_open() && destination.is_open()) {
-            // Create a buffer to hold the contents of the original file
-            std::vector<char> buffer(std::istreambuf_iterator<char>(source), {});
+      // Write the contents of the buffer to the destination file
+      destination.write(buffer.data(), buffer.size());
 
-            // Write the contents of the buffer to the destination file
-            destination.write(buffer.data(), buffer.size());
+      // Append the contents of the buffer 9 times
+      for (auto index = size_t{0}; index < scale_factor - 1; ++index) {
+        destination.write(buffer.data(), buffer.size());
+      }
 
-            // Append the contents of the buffer 9 times
-            for (auto index = size_t{0}; index < scale_factor-1; ++index) {
-                destination.write(buffer.data(), buffer.size());
-            }
-
-            source.close();
-            destination.close();
-        } else {
-            std::cout << "Could not open one of the files" << std::endl;
-        }
+      source.close();
+      destination.close();
+    } else {
+      std::cout << "Could not open one of the files" << std::endl;
     }
+  }
 
   void SetUp(::benchmark::State& state) override {
     const auto size_parameter = state.range(0);
@@ -45,27 +44,27 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
 
     auto fd = int32_t{};
     if (!std::filesystem::exists(filename)) {
-      if(NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS){
-          auto original_file = "benchmark_data_1000.txt";
-          create_large_file(original_file, filename, static_cast<size_t>(size_parameter/1000));
-          chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
-      }else{
-          numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
-          Assert(((fd = creat(filename.c_str(), O_WRONLY)) >= 1),
-                 close_file_and_return_error_message(fd, "Create error: ", errno));
-          chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
-          Assert((static_cast<uint64_t>(write(fd, std::data(numbers), NUMBER_OF_BYTES)) == NUMBER_OF_BYTES),
-                 close_file_and_return_error_message(fd, "Write error: ", errno));
+      if (NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS) {
+        auto original_file = "benchmark_data_1000.txt";
+        create_large_file(original_file, filename, static_cast<size_t>(size_parameter / 1000));
+        chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
+      } else {
+        numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
+        Assert(((fd = creat(filename.c_str(), O_WRONLY)) >= 1),
+               close_file_and_return_error_message(fd, "Create error: ", errno));
+        chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
+        Assert((static_cast<uint64_t>(write(fd, std::data(numbers), NUMBER_OF_BYTES)) == NUMBER_OF_BYTES),
+               close_file_and_return_error_message(fd, "Write error: ", errno));
       }
     }
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
-         close_file_and_return_error_message(fd, "Open error: ", errno));
-  const auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_PRIVATE, fd, 0));
-  Assert((map != MAP_FAILED), close_file_and_return_error_message(fd, "Mapping Failed: ", errno));
-  const auto map_span_view = std::span{map, NUMBER_OF_ELEMENTS};
-  control_sum = std::accumulate(map_span_view.begin(), map_span_view.end(), uint64_t{0});
+    Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+           close_file_and_return_error_message(fd, "Open error: ", errno));
+    const auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, MAP_PRIVATE, fd, 0));
+    Assert((map != MAP_FAILED), close_file_and_return_error_message(fd, "Mapping Failed: ", errno));
+    const auto map_span_view = std::span{map, NUMBER_OF_ELEMENTS};
+    control_sum = std::accumulate(map_span_view.begin(), map_span_view.end(), uint64_t{0});
 
-  close(fd);
+    close(fd);
   }
 
  protected:
@@ -91,12 +90,13 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void libaio_sequential_read_multi_threaded(benchmark::State& state, uint16_t aio_request_count);
   void libaio_random_read(benchmark::State& state, uint16_t aio_request_count);
 #endif
-  void memory_mapped_read_single_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag, const int access_order);
-  #ifdef __linux__
+  void memory_mapped_read_single_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag,
+                                          const int access_order);
+#ifdef __linux__
   void memory_mapped_read_user_space(benchmark::State& state, const uint16_t thread_count, const int access_order);
-  #endif
-  void memory_mapped_read_multi_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag, const uint16_t thread_count, const int access_order);
-
+#endif
+  void memory_mapped_read_multi_threaded(benchmark::State& state, const int mapping_type, const int map_mode_flag,
+                                         const uint16_t thread_count, const int access_order);
 
   // enums for mmap benchmarks
   enum MAPPING_TYPE { MMAP, UMAP };

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -20,24 +20,22 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   void create_random_indexes_if_needed(size_t size_parameter, uint64_t number_of_elements) {
     if (random_indexes.empty() || last_size_parameter != size_parameter) {
       const auto start = std::chrono::high_resolution_clock::now();
-      std::cout << "Creating random_indexes for: " << size_parameter << std::endl;
+      if (verbose)
+        std::cout << "Creating random_indexes for: " << size_parameter << std::endl;
       random_indexes = generate_random_indexes(number_of_elements);
       const auto stop = std::chrono::high_resolution_clock::now();
       const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(stop - start);
-      std::cout << "Elapsed seconds: " << elapsed.count() << std::endl;
+      if (verbose)
+        std::cout << "Elapsed seconds: " << elapsed.count() << std::endl;
+      last_size_parameter = size_parameter;
     }
   }
 
   void SetUp(::benchmark::State& state) override {
     const auto size_parameter = state.range(0);
+
     NUMBER_OF_BYTES = _align_to_pagesize(size_parameter);
     NUMBER_OF_ELEMENTS = NUMBER_OF_BYTES / uint32_t_size;
-
-    const auto ACCESS_TYPE = state.range(2);
-    if (ACCESS_TYPE != 0){
-      create_random_indexes_if_needed(size_parameter, NUMBER_OF_ELEMENTS);
-      last_size_parameter = size_parameter;
-    }
 
     numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
     control_sum = std::accumulate(numbers.begin(), numbers.end(), uint64_t{0});
@@ -47,7 +45,6 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
     file.write(reinterpret_cast<const char*>(numbers.data()), numbers.size() * sizeof(uint32_t));
     chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
     file.close();
-
   }
 
   void TearDown(::benchmark::State& /*state*/) override {

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -41,8 +41,8 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   const ssize_t uint32_t_size = ssize_t{sizeof(uint32_t)};
   std::string filename;
   uint64_t control_sum = uint64_t{0};
-  uint32_t NUMBER_OF_BYTES = uint32_t{0};
-  uint32_t NUMBER_OF_ELEMENTS = uint32_t{0};
+  uint64_t NUMBER_OF_BYTES = uint64_t{0};
+  uint64_t NUMBER_OF_ELEMENTS = uint64_t{0};
   std::vector<uint32_t> numbers = std::vector<uint32_t>{};
   void read_non_atomic_multi_threaded(benchmark::State& state, uint16_t thread_count);
   void read_non_atomic_single_threaded(benchmark::State& state);

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -42,13 +42,13 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
 
   void create_random_indexes_if_not_exist(size_t size_parameter, uint64_t number_of_elements) {
     if (random_indexes.size() == 0) {
-        const auto start = std::chrono::high_resolution_clock::now();
+      const auto start = std::chrono::high_resolution_clock::now();
 
       std::cout << "Creating random_indexes for: " << size_parameter << std::endl;
       random_indexes = generate_random_indexes(number_of_elements);
       const auto stop = std::chrono::high_resolution_clock::now();
       const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(stop - start);
-      std::cout << "Elapes seconds: " << elapsed.count() <<  std::endl;
+      std::cout << "Elapes seconds: " << elapsed.count() << std::endl;
     }
   }
 

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -14,7 +14,7 @@ namespace hyrise {
 class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
 
-    void create_large_file(std::string original_file_name, std::string copied_file_name, uint32_t scale_factor){
+    void create_large_file(std::string original_file_name, std::string copied_file_name, size_t scale_factor){
         std::ifstream source(original_file_name, std::ios::binary);
         std::ofstream destination(copied_file_name, std::ios::binary);
 
@@ -26,7 +26,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
             destination.write(buffer.data(), buffer.size());
 
             // Append the contents of the buffer 9 times
-            for (auto index = uint32_t{0}; index < scale_factor-1; ++index) {
+            for (auto index = size_t{0}; index < scale_factor-1; ++index) {
                 destination.write(buffer.data(), buffer.size());
             }
 
@@ -47,7 +47,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
     if (!std::filesystem::exists(filename)) {
       if(NUMBER_OF_ELEMENTS > MAX_NUMBER_OF_ELEMENTS){
           auto original_file = "benchmark_data_1000.txt";
-          create_large_file(original_file, filename, static_cast<uint32_t>(size_parameter/1000));
+          create_large_file(original_file, filename, static_cast<size_t>(size_parameter/1000));
           chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
       }else{
           numbers = generate_random_positive_numbers(NUMBER_OF_ELEMENTS);
@@ -70,8 +70,9 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
 
  protected:
   const ssize_t uint32_t_size = ssize_t{sizeof(uint32_t)};
-  // MAX_NUMBER_OF_ELEMENTS = NUMBER_OF_ELEMENTS of parameter 1000.
-  const uint64_t MAX_NUMBER_OF_ELEMENTS = uint64_t{250000384};
+  // MAX_NUMBER_OF_ELEMENTS = max. read/write according to man page / uint32_t_size
+  // = 2,147,479,552 bytes / 4 bytes = 536869888
+  const uint64_t MAX_NUMBER_OF_ELEMENTS = uint64_t{536869888};
   std::string filename;
   uint64_t control_sum = uint64_t{0};
   uint64_t NUMBER_OF_BYTES = uint64_t{0};

--- a/src/benchmark/file_io_read_micro_benchmark.hpp
+++ b/src/benchmark/file_io_read_micro_benchmark.hpp
@@ -35,7 +35,7 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
 
     filename = "benchmark_data_" + std::to_string(size_parameter) + ".bin";
     std::ofstream file(filename, std::ios::binary);
-    file.write(reinterpret_cast<const char*>(numbers.data()), numbers.size() * sizeof(uint32_t));
+    file.write(reinterpret_cast<const char*>(numbers.data()), numbers.size() * uint32_t_size);
     chmod(filename.c_str(), S_IRWXU);  // enables owner to rwx file
     file.close();
   }
@@ -45,9 +45,9 @@ class FileIOMicroReadBenchmarkFixture : public MicroBenchmarkBasicFixture {
   }
 
  protected:
-  const ssize_t uint32_t_size = ssize_t{sizeof(uint32_t)};
+  const size_t uint32_t_size = size_t{sizeof(uint32_t)};
   // read / write accept at most up to = 2,147,479,552 bytes
-  const uint64_t MAX_NUMBER_OF_ELEMENTS = uint64_t{536'869'888};
+  const uint64_t MAX_NUMBER_OF_ELEMENTS = 2147479552 / uint32_t_size;
   std::string filename;
   uint64_t control_sum = uint64_t{0};
   uint64_t NUMBER_OF_BYTES = uint64_t{0};

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -41,10 +41,10 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
     // Getting the mapping to memory.
     const auto OFFSET = off_t{0};
 
-    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
+    auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
 
     if (mapping_type == MMAP) {
-      map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
+      map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
     }
 #ifdef __APPLE__
     else {
@@ -53,7 +53,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
 #else
     else if (mapping_type == UMAP) {
       setenv("UMAP_LOG_LEVEL", std::string("ERROR").c_str(), 1);
-      map = reinterpret_cast<int32_t*>(umap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
+      map = reinterpret_cast<uint32_t*>(umap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
     } else {
       Fail("Error: Invalid mapping type.");
     }
@@ -120,7 +120,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_user_space(benchmark::S
     // Getting the mapping to memory.
     const auto OFFSET = off_t{0};
 
-    auto* map = reinterpret_cast<int32_t*>(umap(NULL, NUMBER_OF_BYTES, PROT_READ, PRIVATE, fd, OFFSET));
+    auto* map = reinterpret_cast<uint32_t*>(umap(NULL, NUMBER_OF_BYTES, PROT_READ, PRIVATE, fd, OFFSET));
 
     Assert((map != MAP_FAILED), close_file_and_return_error_message(fd, "Mapping Failed: ", errno));
 

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -329,39 +329,48 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQU
 }
 #endif
 
+static void CustomArguments(benchmark::internal::Benchmark* benchmark) {
+  const std::vector<uint32_t> parameters = {10000, 100000};
+  const std::vector<uint8_t> thread_counts = {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64};
+
+  for (auto param_index = size_t{0}; param_index < parameters.size(); ++param_index)
+    for (auto thread_index = size_t{0}; thread_index < thread_counts.size(); ++thread_index)
+      benchmark->Args({parameters[param_index], thread_counts[thread_index]});
+}
+
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL_OLD)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 #endif
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM_OLD)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 #endif
 

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -65,7 +65,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
     if (access_order == RANDOM) {
       madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
       state.PauseTiming();
-      const auto random_indexes = random_indexes_map[state.range(0)];
+      //const auto random_indexes = random_indexes_map[state.range(0)];
       //const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
       state.ResumeTiming();
       for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
@@ -195,7 +195,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
 
     if (access_order == RANDOM) {
       state.PauseTiming();
-      const auto random_indexes = random_indexes_map[state.range(0)];
+      //const auto random_indexes = random_indexes_map[state.range(0)];
       //const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
       state.ResumeTiming();
 
@@ -330,35 +330,35 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQU
 #endif
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL_OLD)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM_OLD)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 #endif
 

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -8,15 +8,15 @@ namespace {
 
 // Worker function for threading.
 void read_mmap_chunk_sequential(const size_t from, const size_t to, const int32_t* map, uint64_t& sum) {
-  for (auto index = size_t{0} + from; index < to; ++index) {
+  for (auto index = uint64_t{0} + from; index < to; ++index) {
     sum += map[index];
   }
 }
 
 // Worker function for threading.
 void read_mmap_chunk_random(const size_t from, const size_t to, const int32_t* map, uint64_t& sum,
-                            const std::vector<uint32_t>& random_indexes) {
-  for (auto index = size_t{0} + from; index < to; ++index) {
+                            const std::vector<uint64_t>& random_indexes) {
+  for (auto index = uint64_t{0} + from; index < to; ++index) {
     sum += map[random_indexes[index]];
   }
 }
@@ -128,7 +128,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_user_space(benchmark::S
       state.PauseTiming();
       const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
       state.ResumeTiming();
-      for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+      for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
         sum += map[random_indexes[index]];
       }
     } else /* if (access_order == SEQUENTIAL) */ {

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -326,35 +326,35 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQU
 #endif
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)
-    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL_OLD)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM_OLD)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 #endif
 

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -329,15 +329,6 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQU
 }
 #endif
 
-static void CustomArguments(benchmark::internal::Benchmark* benchmark) {
-  const std::vector<uint32_t> parameters = {10000, 100000};
-  const std::vector<uint8_t> thread_counts = {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64};
-
-  for (auto param_index = size_t{0}; param_index < parameters.size(); ++param_index)
-    for (auto thread_index = size_t{0}; thread_index < thread_counts.size(); ++thread_index)
-      benchmark->Args({parameters[param_index], thread_counts[thread_index]});
-}
-
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
     ->Apply(CustomArguments)
     ->UseRealTime();

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -128,7 +128,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_user_space(benchmark::S
     if (access_order == RANDOM) {
       madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
       state.PauseTiming();
-      const auto random_indexes = random_indexes_map[state.range(0)];
+      //const auto random_indexes = random_indexes_map[state.range(0)];
       //const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
       state.ResumeTiming();
       for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -133,7 +133,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_user_space(benchmark::S
       }
     } else /* if (access_order == SEQUENTIAL) */ {
       madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
-      for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+      for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
         sum += map[index];
       }
     }

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -67,12 +67,12 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
       state.PauseTiming();
       const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
       state.ResumeTiming();
-      for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+      for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
         sum += map[random_indexes[index]];
       }
     } else /* if (access_order == SEQUENTIAL) */ {
       madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
-      for (auto index = size_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
+      for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
         sum += map[index];
       }
     }
@@ -199,10 +199,10 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
         madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
       }
 
-      for (auto i = size_t{0}; i < thread_count; ++i) {
+      for (auto i = uint64_t{0}; i < thread_count; ++i) {
         const auto from = batch_size * i;
         auto to = from + batch_size;
-        if (i == static_cast<size_t>(thread_count-1)){
+        if (i == static_cast<uint64_t>(thread_count-1)){
             to = NUMBER_OF_ELEMENTS;
         }
         // std::ref fix from https://stackoverflow.com/a/73642536
@@ -213,10 +213,10 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
         madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
       }
 
-      for (auto i = size_t{0}; i < thread_count; ++i) {
+      for (auto i = uint64_t{0}; i < thread_count; ++i) {
         const auto from = batch_size * i;
         auto to = from + batch_size;
-        if (i == static_cast<size_t>(thread_count-1)){
+        if (i == static_cast<uint64_t>(thread_count-1)){
             to = NUMBER_OF_ELEMENTS;
         }
         // std::ref fix from https://stackoverflow.com/a/73642536

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -99,15 +99,17 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
 }
 
 #ifdef __linux__
-void FileIOMicroReadBenchmarkFixture::memory_mapped_read_user_space(benchmark::State& state, const uint16_t thread_count,
-  const int access_order) {
+void FileIOMicroReadBenchmarkFixture::memory_mapped_read_user_space(benchmark::State& state,
+                                                                    const uint16_t thread_count,
+                                                                    const int access_order) {
   // Set number of threads used by UMAP.
   setenv("UMAP_PAGE_FILLERS", std::to_string(thread_count).c_str(), 1);
   setenv("UMAP_PAGE_EVICTORS", std::to_string(thread_count).c_str(), 1);
   setenv("UMAP_LOG_LEVEL", std::string("ERROR").c_str(), 1);
 
   auto fd = int32_t{};
-  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0), close_file_and_return_error_message(fd, "Open error: ", errno));
+  Assert(((fd = open(filename.c_str(), O_RDONLY)) >= 0),
+         close_file_and_return_error_message(fd, "Open error: ", errno));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -118,7 +120,6 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_user_space(benchmark::S
     const auto OFFSET = off_t{0};
 
     auto* map = reinterpret_cast<int32_t*>(umap(NULL, NUMBER_OF_BYTES, PROT_READ, PRIVATE, fd, OFFSET));
-
 
     Assert((map != MAP_FAILED), close_file_and_return_error_message(fd, "Mapping Failed: ", errno));
 
@@ -202,11 +203,11 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
       for (auto i = size_t{0}; i < thread_count; ++i) {
         const auto from = batch_size * i;
         auto to = from + batch_size;
-        if (i == static_cast<size_t>(thread_count-1)){
-            to = NUMBER_OF_ELEMENTS;
+        if (i == static_cast<size_t>(thread_count - 1)) {
+          to = NUMBER_OF_ELEMENTS;
         }
         // std::ref fix from https://stackoverflow.com/a/73642536
-        threads[i] = std::thread(read_mmap_chunk_random, from, to, map, std::ref(sums[i]), random_indexes);
+        threads[i] = std::thread(read_mmap_chunk_random, from, to, map, std::ref(sums[i]), std::ref(random_indexes));
       }
     } else {
       if (mapping_type == MMAP) {
@@ -216,8 +217,8 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
       for (auto i = size_t{0}; i < thread_count; ++i) {
         const auto from = batch_size * i;
         auto to = from + batch_size;
-        if (i == static_cast<size_t>(thread_count-1)){
-            to = NUMBER_OF_ELEMENTS;
+        if (i == static_cast<size_t>(thread_count - 1)) {
+          to = NUMBER_OF_ELEMENTS;
         }
         // std::ref fix from https://stackoverflow.com/a/73642536
         threads[i] = std::thread(read_mmap_chunk_sequential, from, to, map, std::ref(sums[i]));
@@ -231,7 +232,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
     const auto total_sum = std::accumulate(sums.begin(), sums.end(), uint64_t{0});
 
     Assert(control_sum == total_sum, "Sanity check failed: Not the same result. Got: " + std::to_string(total_sum) +
-                                 " Expected: " + std::to_string(control_sum) + ".");
+                                         " Expected: " + std::to_string(control_sum) + ".");
     state.ResumeTiming();
 
     if (mapping_type == MMAP) {
@@ -309,10 +310,10 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQU
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM_OLD)(benchmark::State& state) {
   const auto thread_count = static_cast<uint16_t>(state.range(1));
   if (thread_count == 1) {
-     memory_mapped_read_single_threaded(state, UMAP, PRIVATE, RANDOM);
-   } else {
-     memory_mapped_read_multi_threaded(state, UMAP, PRIVATE, thread_count, RANDOM);
-   }
+    memory_mapped_read_single_threaded(state, UMAP, PRIVATE, RANDOM);
+  } else {
+    memory_mapped_read_multi_threaded(state, UMAP, PRIVATE, thread_count, RANDOM);
+  }
 }
 
 BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL_OLD)(benchmark::State& state) {
@@ -326,35 +327,35 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQU
 #endif
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 #ifdef __linux__
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL_OLD)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM_OLD)
-    ->ArgsProduct({{10000,100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 #endif
 

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -159,7 +159,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
          close_file_and_return_error_message(fd, "Open error: ", errno));
 
   auto threads = std::vector<std::thread>(thread_count);
-  const auto batch_size = static_cast<uint64_t>(static_cast<float>(NUMBER_OF_ELEMENTS) / thread_count);
+  const auto batch_size = static_cast<uint64_t>(NUMBER_OF_ELEMENTS / thread_count);
 
   for (auto _ : state) {
     state.PauseTiming();

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -7,14 +7,14 @@
 namespace {
 
 // Worker function for threading.
-void read_mmap_chunk_sequential(const size_t from, const size_t to, const int32_t* map, uint64_t& sum) {
+void read_mmap_chunk_sequential(const size_t from, const size_t to, const uint32_t* map, uint64_t& sum) {
   for (auto index = uint64_t{0} + from; index < to; ++index) {
     sum += map[index];
   }
 }
 
 // Worker function for threading.
-void read_mmap_chunk_random(const size_t from, const size_t to, const int32_t* map, uint64_t& sum,
+void read_mmap_chunk_random(const size_t from, const size_t to, const uint32_t* map, uint64_t& sum,
                             const std::vector<uint64_t>& random_indexes) {
   for (auto index = uint64_t{0} + from; index < to; ++index) {
     sum += map[random_indexes[index]];
@@ -170,10 +170,10 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
     // Getting the mapping to memory.
     const auto OFFSET = off_t{0};
 
-    auto* map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
+    auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
 
     if (mapping_type == MMAP) {
-      map = reinterpret_cast<int32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
+      map = reinterpret_cast<uint32_t*>(mmap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
     }
 #ifdef __APPLE__
     else {
@@ -182,7 +182,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
 #else
     else if (mapping_type == UMAP) {
       setenv("UMAP_LOG_LEVEL", std::string("ERROR").c_str(), 1);
-      map = reinterpret_cast<int32_t*>(umap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
+      map = reinterpret_cast<uint32_t*>(umap(NULL, NUMBER_OF_BYTES, PROT_READ, map_mode_flag, fd, OFFSET));
     } else {
       Fail("Error: Invalid mapping type.");
     }
@@ -199,10 +199,10 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
         madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
       }
 
-      for (auto i = uint64_t{0}; i < thread_count; ++i) {
+      for (auto i = size_t{0}; i < thread_count; ++i) {
         const auto from = batch_size * i;
         auto to = from + batch_size;
-        if (i == static_cast<uint64_t>(thread_count-1)){
+        if (i == static_cast<size_t>(thread_count-1)){
             to = NUMBER_OF_ELEMENTS;
         }
         // std::ref fix from https://stackoverflow.com/a/73642536
@@ -213,10 +213,10 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
         madvise(map, NUMBER_OF_BYTES, MADV_SEQUENTIAL);
       }
 
-      for (auto i = uint64_t{0}; i < thread_count; ++i) {
+      for (auto i = size_t{0}; i < thread_count; ++i) {
         const auto from = batch_size * i;
         auto to = from + batch_size;
-        if (i == static_cast<uint64_t>(thread_count-1)){
+        if (i == static_cast<size_t>(thread_count-1)){
             to = NUMBER_OF_ELEMENTS;
         }
         // std::ref fix from https://stackoverflow.com/a/73642536

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -202,7 +202,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
       for (auto i = size_t{0}; i < thread_count; ++i) {
         const auto from = batch_size * i;
         auto to = from + batch_size;
-        if (i == thread_count-1){
+        if (i == static_cast<size_t>(thread_count-1)){
             to = NUMBER_OF_ELEMENTS;
         }
         // std::ref fix from https://stackoverflow.com/a/73642536
@@ -216,7 +216,7 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
       for (auto i = size_t{0}; i < thread_count; ++i) {
         const auto from = batch_size * i;
         auto to = from + batch_size;
-        if (i == thread_count-1){
+        if (i == static_cast<size_t>(thread_count-1)){
             to = NUMBER_OF_ELEMENTS;
         }
         // std::ref fix from https://stackoverflow.com/a/73642536
@@ -326,18 +326,18 @@ BENCHMARK_DEFINE_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQU
 #endif
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)
-    ->ArgsProduct({{10, 100, 1000, 10000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->ArgsProduct({{10000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}})
     ->UseRealTime();
 
 #ifdef __linux__

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -65,7 +65,8 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_single_threaded(benchma
     if (access_order == RANDOM) {
       madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
       state.PauseTiming();
-      const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
+      const auto random_indexes = random_indexes_map[state.range(0)];
+      //const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
       state.ResumeTiming();
       for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
         sum += map[random_indexes[index]];
@@ -127,7 +128,8 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_user_space(benchmark::S
     if (access_order == RANDOM) {
       madvise(map, NUMBER_OF_BYTES, MADV_RANDOM);
       state.PauseTiming();
-      const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
+      const auto random_indexes = random_indexes_map[state.range(0)];
+      //const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
       state.ResumeTiming();
       for (auto index = uint64_t{0}; index < NUMBER_OF_ELEMENTS; ++index) {
         sum += map[random_indexes[index]];
@@ -193,7 +195,8 @@ void FileIOMicroReadBenchmarkFixture::memory_mapped_read_multi_threaded(benchmar
 
     if (access_order == RANDOM) {
       state.PauseTiming();
-      const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
+      const auto random_indexes = random_indexes_map[state.range(0)];
+      //const auto random_indexes = generate_random_indexes(NUMBER_OF_ELEMENTS);
       state.ResumeTiming();
 
       if (mapping_type == MMAP) {

--- a/src/benchmark/file_io_read_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_read_mmap_benchmark.cpp
@@ -333,15 +333,8 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_SE
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
-    ->UseRealTime();
-
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_SEQUENTIAL)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
-    ->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
 #ifdef __linux__
@@ -349,12 +342,22 @@ BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SE
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
     ->UseRealTime();
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM)
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL_OLD)
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+    ->UseRealTime();
+#endif
+
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_PRIVATE_RANDOM)
     ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
-BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_SEQUENTIAL_OLD)
-    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {0}})
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, MMAP_ATOMIC_MAP_SHARED_RANDOM)
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
+    ->UseRealTime();
+
+#ifdef __linux__
+BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM)
+    ->ArgsProduct({{10000, 100000}, {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64}, {1}})
     ->UseRealTime();
 
 BENCHMARK_REGISTER_F(FileIOMicroReadBenchmarkFixture, UMAP_ATOMIC_MAP_PRIVATE_RANDOM_OLD)

--- a/src/benchmark/file_io_write_micro_benchmark.cpp
+++ b/src/benchmark/file_io_write_micro_benchmark.cpp
@@ -303,15 +303,25 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark:
 }
 
 // Arguments are file size in MB
+static void CustomArguments(benchmark::internal::Benchmark* benchmark) {
+  const std::vector<uint32_t> parameters = {10000, 100000};
+  const std::vector<uint8_t> thread_counts = {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64};
+
+  for (auto param_index = size_t{0}; param_index < parameters.size(); ++param_index)
+    for (auto thread_index = size_t{0}; thread_index < thread_counts.size(); ++thread_index)
+      benchmark->Args({parameters[param_index], thread_counts[thread_index]});
+}
+
+
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC_THREADED)
-    ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC_THREADED)
-    ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, AIO_THREADED)
-    ->ArgsProduct({{10, 100, 1000}, {1, 2, 4, 8, 16, 32, 48}})
+    ->Apply(CustomArguments)
     ->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)->Arg(10)->Arg(100)->Arg(1000)->UseRealTime();
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)->Arg(10000)->Arg(100000)->UseRealTime();
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_write_micro_benchmark.cpp
+++ b/src/benchmark/file_io_write_micro_benchmark.cpp
@@ -39,7 +39,8 @@ void write_data_using_aio(const size_t from, const size_t to, int32_t fd, uint32
 
   /* Wait until end of transaction */
   auto err = int{0};
-  while ((err = aio_error(&aiocb)) == EINPROGRESS);
+  while ((err = aio_error(&aiocb)) == EINPROGRESS)
+    ;
 
   aio_error_handling(&aiocb, bytes_to_write);
 }
@@ -199,7 +200,8 @@ void FileIOWriteMicroBenchmarkFixture::aio_single_threaded(benchmark::State& sta
 
     /* Wait until end of transaction */
     auto err = int{0};
-    while ((err = aio_error(&aiocb)) == EINPROGRESS);
+    while ((err = aio_error(&aiocb)) == EINPROGRESS)
+      ;
 
     aio_error_handling(&aiocb, NUMBER_OF_BYTES);
 
@@ -302,26 +304,11 @@ BENCHMARK_DEFINE_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)(benchmark:
   }
 }
 
-// Arguments are file size in MB
-static void CustomArguments(benchmark::internal::Benchmark* benchmark) {
-  const std::vector<uint32_t> parameters = {10000, 100000};
-  const std::vector<uint8_t> thread_counts = {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64};
-
-  for (auto param_index = size_t{0}; param_index < parameters.size(); ++param_index)
-    for (auto thread_index = size_t{0}; thread_index < thread_counts.size(); ++thread_index)
-      benchmark->Args({parameters[param_index], thread_counts[thread_index]});
-}
-
-
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, WRITE_NON_ATOMIC_THREADED)
     ->Apply(CustomArguments)
     ->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC_THREADED)
-    ->Apply(CustomArguments)
-    ->UseRealTime();
-BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, AIO_THREADED)
-    ->Apply(CustomArguments)
-    ->UseRealTime();
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, PWRITE_ATOMIC_THREADED)->Apply(CustomArguments)->UseRealTime();
+BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, AIO_THREADED)->Apply(CustomArguments)->UseRealTime();
 BENCHMARK_REGISTER_F(FileIOWriteMicroBenchmarkFixture, IN_MEMORY_WRITE)->Arg(10000)->Arg(100000)->UseRealTime();
 
 }  // namespace hyrise

--- a/src/benchmark/file_io_write_mmap_benchmark.cpp
+++ b/src/benchmark/file_io_write_mmap_benchmark.cpp
@@ -56,7 +56,7 @@ void FileIOWriteMmapBenchmarkFixture::mmap_write_single_threaded(benchmark::Stat
         // Generating random indexes should not play a role in the benchmark.
         const auto ind_access_order = generate_random_indexes(NUMBER_OF_ELEMENTS);
         state.ResumeTiming();
-        for (auto idx = uint32_t{0}; idx < ind_access_order.size(); ++idx) {
+        for (auto idx = uint64_t{0}; idx < ind_access_order.size(); ++idx) {
           auto access_index = ind_access_order[idx];
           map[access_index] = data_to_write[idx];
         }
@@ -97,7 +97,7 @@ void write_mmap_chunk_sequential(const size_t from, const size_t to, int32_t* ma
 
 void write_mmap_chunk_random(const size_t from, const size_t to, int32_t* map,
                              const std::vector<uint32_t>& data_to_write,
-                             const std::vector<uint32_t>& ind_access_order) {
+                             const std::vector<uint64_t>& ind_access_order) {
   for (auto idx = from; idx < to; ++idx) {
     auto access_index = ind_access_order[idx];
     map[access_index] = data_to_write[idx];

--- a/src/benchmark/micro_benchmark_basic_fixture.cpp
+++ b/src/benchmark/micro_benchmark_basic_fixture.cpp
@@ -42,7 +42,8 @@ void MicroBenchmarkBasicFixture::_clear_cache() {
 
 uint64_t MicroBenchmarkBasicFixture::_align_to_pagesize(const uint64_t buffer_size_mb, const uint64_t page_size) {
   auto buffer_size = buffer_size_mb * MB;
-  const auto multiplier = static_cast<uint64_t>(std::ceil(static_cast<float>(buffer_size) / static_cast<float>(page_size)));
+  const auto multiplier =
+      static_cast<uint64_t>(std::ceil(static_cast<float>(buffer_size) / static_cast<float>(page_size)));
   return page_size * multiplier;
 }
 

--- a/src/benchmark/micro_benchmark_basic_fixture.cpp
+++ b/src/benchmark/micro_benchmark_basic_fixture.cpp
@@ -10,7 +10,7 @@
 
 namespace hyrise {
 
-const auto MB = uint32_t{1'000'000};
+const auto MB = uint64_t{1'000'000};
 
 void MicroBenchmarkBasicFixture::SetUp(::benchmark::State& /*state*/) {
   const auto chunk_size = ChunkOffset{2'000};
@@ -40,9 +40,9 @@ void MicroBenchmarkBasicFixture::_clear_cache() {
   micro_benchmark_clear_cache();
 }
 
-uint32_t MicroBenchmarkBasicFixture::_align_to_pagesize(const uint32_t buffer_size_mb, const uint32_t page_size) {
+uint64_t MicroBenchmarkBasicFixture::_align_to_pagesize(const uint64_t buffer_size_mb, const uint64_t page_size) {
   auto buffer_size = buffer_size_mb * MB;
-  const auto multiplier = static_cast<uint32_t>(std::ceil(static_cast<float>(buffer_size) / static_cast<float>(page_size)));
+  const auto multiplier = static_cast<uint64_t>(std::ceil(static_cast<float>(buffer_size) / static_cast<float>(page_size)));
   return page_size * multiplier;
 }
 

--- a/src/benchmark/micro_benchmark_basic_fixture.hpp
+++ b/src/benchmark/micro_benchmark_basic_fixture.hpp
@@ -27,7 +27,7 @@ class MicroBenchmarkBasicFixture : public benchmark::Fixture {
    * @param page size
    * @return alligned amound of memory in bytes
    */
-  uint32_t _align_to_pagesize(uint32_t buffer_size_mb, uint32_t page_size = 4096);
+  uint64_t _align_to_pagesize(uint64_t buffer_size_mb, uint64_t page_size = 4096);
 
  protected:
   std::shared_ptr<TableWrapper> _table_wrapper_a;

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -48,7 +48,7 @@ void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes) {
 /**
  * Generates a vector containing random indexes between 0 and number.
 */
-std::vector<uint32_t> generate_random_indexes(uint32_t number) {
+std::vector<uint32_t> generate_random_indexes(uint64_t number) {
   std::vector<uint32_t> sequence(number);
   std::iota(std::begin(sequence), std::end(sequence), 0);
   auto rng = std::default_random_engine{};
@@ -57,7 +57,7 @@ std::vector<uint32_t> generate_random_indexes(uint32_t number) {
   return sequence;
 }
 
-std::vector<uint32_t> generate_random_positive_numbers(uint32_t size) {
+std::vector<uint32_t> generate_random_positive_numbers(uint64_t size) {
   auto numbers = std::vector<uint32_t>(size);
   for (auto index = size_t{0}; index < size; ++index) {
     numbers[index] = std::rand() % UINT32_MAX;

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -35,6 +35,16 @@ void micro_benchmark_clear_disk_cache() {
 }
 
 
+void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes) {
+    const auto err = aio_error(aiocb);
+    const auto ret = aio_return(aiocb);
+
+    Assert(err == 0, "Error at aio_error(): " + std::strerror(errno));
+
+    Assert(ret == static_cast<int32_t>(expected_bytes),
+           "Error at aio_return(). Got: " + std::to_string(ret) + " Expected: " + std::to_string(expected_bytes) + ".");
+}
+
 /**
  * Generates a vector containing random indexes between 0 and number.
 */

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -34,45 +34,21 @@ void micro_benchmark_clear_disk_cache() {
 #endif
 }
 
-void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes) {
-  const auto err = aio_error(aiocb);
-  const auto ret = aio_return(aiocb);
-
-  Assert(err == 0, "Error at aio_error(): " + std::strerror(errno));
-
-  Assert(ret == static_cast<int32_t>(expected_bytes),
-         "Error at aio_return(). Got: " + std::to_string(ret) + " Expected: " + std::to_string(expected_bytes) + ".");
-}
-
 
 /**
  * Generates a vector containing random indexes between 0 and number.
 */
-std::vector<uint32_t> generate_random_indexes(uint64_t number) {
-    /*
-    std::vector<uint32_t> sequence(number);
-
-    std::iota(std::begin(sequence), std::end(sequence), 0);
-    auto rng = std::default_random_engine{};
-    std::shuffle(std::begin(sequence), std::end(sequence), rng);
-     */
-  auto indexes = std::vector<uint32_t>(number);
-  auto printed_out = false;
-  for (auto index = size_t{0}; index < number; ++index) {
-      indexes[index] = index % UINT32_MAX;
-      if (index > UINT32_MAX && !printed_out){
-          std::cout << "Aha! Found the error: " << index << std::endl;
-          printed_out = true;
-      }
-  }
+std::vector<uint64_t> generate_random_indexes(uint64_t size) {
+  std::vector<uint64_t> sequence(size);
+  std::iota(std::begin(sequence), std::end(sequence), 0);
   auto rng = std::default_random_engine{};
-  std::shuffle(std::begin(indexes), std::end(indexes), rng);
-  return indexes;
+  std::shuffle(std::begin(sequence), std::end(sequence), rng);
+  return sequence;
 }
 
 std::vector<uint32_t> generate_random_positive_numbers(uint64_t size) {
   auto numbers = std::vector<uint32_t>(size);
-  for (auto index = size_t{0}; index < size; ++index) {
+  for (auto index = uint64_t{0}; index < size; ++index) {
     numbers[index] = std::rand() % UINT32_MAX;
   }
 

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -57,10 +57,12 @@ std::vector<uint32_t> generate_random_indexes(uint64_t number) {
     std::shuffle(std::begin(sequence), std::end(sequence), rng);
      */
   auto indexes = std::vector<uint32_t>(number);
+  auto printed_out = false;
   for (auto index = size_t{0}; index < number; ++index) {
       indexes[index] = index % UINT32_MAX;
-      if (index % UINT32_MAX != 0){
+      if (index > UINT32_MAX && !printed_out){
           std::cout << "Aha! Found the error: " << index << std::endl;
+          printed_out = true;
       }
   }
   auto rng = std::default_random_engine{};

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -49,12 +49,23 @@ void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes) {
  * Generates a vector containing random indexes between 0 and number.
 */
 std::vector<uint32_t> generate_random_indexes(uint64_t number) {
-  std::vector<uint32_t> sequence(number);
-  std::iota(std::begin(sequence), std::end(sequence), 0);
-  auto rng = std::default_random_engine{};
-  std::shuffle(std::begin(sequence), std::end(sequence), rng);
+    /*
+    std::vector<uint32_t> sequence(number);
 
-  return sequence;
+    std::iota(std::begin(sequence), std::end(sequence), 0);
+    auto rng = std::default_random_engine{};
+    std::shuffle(std::begin(sequence), std::end(sequence), rng);
+     */
+  auto indexes = std::vector<uint32_t>(number);
+  for (auto index = size_t{0}; index < number; ++index) {
+      indexes[index] = index % UINT32_MAX;
+      if (index % UINT32_MAX != 0){
+          std::cout << "Aha! Found the error: " << index << std::endl;
+      }
+  }
+  auto rng = std::default_random_engine{};
+  std::shuffle(std::begin(indexes), std::end(indexes), rng);
+  return indexes;
 }
 
 std::vector<uint32_t> generate_random_positive_numbers(uint64_t size) {

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -1,4 +1,5 @@
 #include "micro_benchmark_utils.hpp"
+#include "micro_benchmark_basic_fixture.hpp"
 #include "utils/assert.hpp"
 
 #include <aio.h>
@@ -75,6 +76,16 @@ std::string close_files_and_return_error_message(std::vector<int32_t> filedescri
     close(filedescriptors[index]);
   }
   return message + std::strerror(error_num);
+}
+
+// Arguments are file size in MB
+void CustomArguments(benchmark::internal::Benchmark* benchmark) {
+  const std::vector<uint32_t> parameters = {10000, 100000};
+  const std::vector<uint8_t> thread_counts = {1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64};
+
+  for (auto param_index = size_t{0}; param_index < parameters.size(); ++param_index)
+    for (auto thread_index = size_t{0}; thread_index < thread_counts.size(); ++thread_index)
+      benchmark->Args({parameters[param_index], thread_counts[thread_index]});
 }
 
 }  // namespace hyrise

--- a/src/benchmark/micro_benchmark_utils.cpp
+++ b/src/benchmark/micro_benchmark_utils.cpp
@@ -3,10 +3,10 @@
 
 #include <aio.h>
 #include <stddef.h>
-#include <unistd.h>
-#include <fstream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <fstream>
 
 #include <algorithm>
 #include <cstring>
@@ -26,23 +26,22 @@ void micro_benchmark_clear_disk_cache() {
   // TODO(phoenix): better documentation of which caches we are clearing
   sync();
 #ifdef __APPLE__
-  auto return_val =  system("purge");
-  (void) return_val;
+  auto return_val = system("purge");
+  (void)return_val;
 #else
   auto return_val = system("echo 3 > /proc/sys/vm/drop_caches");
-  (void) return_val;
+  (void)return_val;
 #endif
 }
 
-
 void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes) {
-    const auto err = aio_error(aiocb);
-    const auto ret = aio_return(aiocb);
+  const auto err = aio_error(aiocb);
+  const auto ret = aio_return(aiocb);
 
-    Assert(err == 0, "Error at aio_error(): " + std::strerror(errno));
+  Assert(err == 0, "Error at aio_error(): " + std::strerror(errno));
 
-    Assert(ret == static_cast<int32_t>(expected_bytes),
-           "Error at aio_return(). Got: " + std::to_string(ret) + " Expected: " + std::to_string(expected_bytes) + ".");
+  Assert(ret == static_cast<int32_t>(expected_bytes),
+         "Error at aio_return(). Got: " + std::to_string(ret) + " Expected: " + std::to_string(expected_bytes) + ".");
 }
 
 /**
@@ -70,7 +69,8 @@ std::string close_file_and_return_error_message(int32_t fd, std::string message,
   return message + std::strerror(error_num);
 }
 
-std::string close_files_and_return_error_message(std::vector<int32_t> filedescriptors, std::string message, const int error_num) {
+std::string close_files_and_return_error_message(std::vector<int32_t> filedescriptors, std::string message,
+                                                 const int error_num) {
   for (auto index = size_t{0}; index < filedescriptors.size(); ++index) {
     close(filedescriptors[index]);
   }

--- a/src/benchmark/micro_benchmark_utils.hpp
+++ b/src/benchmark/micro_benchmark_utils.hpp
@@ -9,6 +9,7 @@ namespace hyrise {
 
 void micro_benchmark_clear_cache();
 void micro_benchmark_clear_disk_cache();
+void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes);
 std::vector<uint64_t> generate_random_indexes(uint64_t size);
 std::vector<uint32_t> generate_random_positive_numbers(uint64_t size);
 

--- a/src/benchmark/micro_benchmark_utils.hpp
+++ b/src/benchmark/micro_benchmark_utils.hpp
@@ -16,5 +16,6 @@ std::vector<uint32_t> generate_random_positive_numbers(uint64_t size);
 // Closes the passed filedescriptor(s) and prints the passed message together with the error message belonging to the
 // passed error number. Might be used in an Assert or Fail statement.
 std::string close_file_and_return_error_message(int32_t fd, std::string message, int error_num);
-std::string close_files_and_return_error_message(std::vector<int32_t> filedescriptors, std::string message, int error_num);
+std::string close_files_and_return_error_message(std::vector<int32_t> filedescriptors, std::string message,
+                                                 int error_num);
 }  // namespace hyrise

--- a/src/benchmark/micro_benchmark_utils.hpp
+++ b/src/benchmark/micro_benchmark_utils.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "micro_benchmark_basic_fixture.hpp"
+
 namespace hyrise {
 
 void micro_benchmark_clear_cache();
@@ -12,6 +14,8 @@ void micro_benchmark_clear_disk_cache();
 void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes);
 std::vector<uint64_t> generate_random_indexes(uint64_t size);
 std::vector<uint32_t> generate_random_positive_numbers(uint64_t size);
+// Arguments are file size in MB
+void CustomArguments(benchmark::internal::Benchmark* benchmark);
 
 // Closes the passed filedescriptor(s) and prints the passed message together with the error message belonging to the
 // passed error number. Might be used in an Assert or Fail statement.

--- a/src/benchmark/micro_benchmark_utils.hpp
+++ b/src/benchmark/micro_benchmark_utils.hpp
@@ -10,8 +10,8 @@ namespace hyrise {
 void micro_benchmark_clear_cache();
 void micro_benchmark_clear_disk_cache();
 void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes);
-std::vector<uint32_t> generate_random_indexes(uint32_t number);
-std::vector<uint32_t> generate_random_positive_numbers(uint32_t size);
+std::vector<uint32_t> generate_random_indexes(uint64_t number);
+std::vector<uint32_t> generate_random_positive_numbers(uint64_t size);
 
 // Closes the passed filedescriptor(s) and prints the passed message together with the error message belonging to the
 // passed error number. Might be used in an Assert or Fail statement.

--- a/src/benchmark/micro_benchmark_utils.hpp
+++ b/src/benchmark/micro_benchmark_utils.hpp
@@ -9,8 +9,7 @@ namespace hyrise {
 
 void micro_benchmark_clear_cache();
 void micro_benchmark_clear_disk_cache();
-void aio_error_handling(aiocb* aiocb, uint32_t expected_bytes);
-std::vector<uint32_t> generate_random_indexes(uint64_t number);
+std::vector<uint64_t> generate_random_indexes(uint64_t size);
 std::vector<uint32_t> generate_random_positive_numbers(uint64_t size);
 
 // Closes the passed filedescriptor(s) and prints the passed message together with the error message belonging to the


### PR DESCRIPTION
Without any code adaptions, we run into some overflows and the generated files look like this:
<img width="664" alt="Bildschirm­foto 2023-01-22 um 18 43 42" src="https://user-images.githubusercontent.com/12445789/213931350-7088fc43-22ea-4af9-b56c-39e4965842ca.png">
