### PR TITLE
Implementing file format in Playground

### DIFF
--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -169,7 +169,7 @@ void write_chunk(const std::shared_ptr<Chunk> chunk, const std::string& chunk_fi
   const auto segment_count = chunk->column_count();
 
   for (auto segment_index = size_t{0}; segment_index < segment_count; ++segment_index) {
-    const auto abstract_segment = chunk->get_segment(static_cast<ColumnID>(segment_index));
+    const auto abstract_segment = chunk->get_segment(static_cast<ColumnID>(static_cast<uint16_t>(segment_index)));
     const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(abstract_segment);
     write_dict_segment(dict_segment, filename);
   }
@@ -265,7 +265,7 @@ int main() {
   std::remove("test_chunk.bin"); //remove previously written file
 
   file_header header;
-  header.storage.format_version_id = 1;
+  header.storage_format_version_id = 1;
   header.chunk_count = 50;
   header.column_count = 3;
   header.row_count = row_count;
@@ -273,6 +273,7 @@ int main() {
   header.chunk_offset_ends = chunk_offset_ends;
   
   (void) header;
+  
 
   std::ofstream chunk_file;
   chunk_file.open("test_chunk.bin", std::ios::out | std::ios::binary | std::ios::app);
@@ -310,14 +311,14 @@ int main() {
   // print row 17 of created and mapped chunk
   std::cout << "Row 17 of created chunk: ";
   for (auto column_index = size_t{0}; column_index < segment_count; ++column_index) {
-    const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(dictionary_chunk->get_segment(static_cast<ColumnID>(column_index)));
+    const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(dictionary_chunk->get_segment(static_cast<ColumnID>(static_cast<uint16_t>(column_index))));
     std::cout << (dict_segment->get_typed_value(ChunkOffset{16})).value() << " ";
   }
   std::cout << std::endl;
 
   std::cout << "Row 17 of mapped chunk: ";
   for (auto column_index = size_t{0}; column_index < segment_count; ++column_index) {
-    const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunk->get_segment(static_cast<ColumnID>(column_index)));
+    const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunk->get_segment(static_cast<ColumnID>(static_cast<uint16_t>(column_index))));
     std::cout << (dict_segment->get_typed_value(ChunkOffset{16})).value() << " ";
   }
 

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -17,6 +17,15 @@
 
 using namespace hyrise;  // NOLINT
 
+struct file_header {
+  uint16_t storage_format_version_id;
+  uint16_t chunk_count;
+  uint16_t column_count;
+  uint32_t row_count;
+  std::array<uint32_t, 50> chunk_ids;
+  std::array<uint32_t, 50> chunk_offset_ends;
+};
+
 std::string fail_and_close_file(const int32_t fd, const std::string& message, const int error_num) {
   close(fd);
   return message + std::strerror(error_num);

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -255,7 +255,30 @@ int main() {
   const auto dictionary_chunk = create_dictionary_segment_chunk(row_count, segment_count);
   const auto chunk_name = "test_chunk";
 
+  auto chunk_ids = std::vector<uint32_t>(50);
+  auto chunk_offset_ends = std::vector<uint32_t>(50);
+  for (auto ind = uint32_t{0}; ind < 50; ++ind) {
+    chunk_ids[ind] = ind;
+    chunk_offset_ends[ind] = ind;
+  }
+
   std::remove("test_chunk.bin"); //remove previously written file
+
+  file_header header;
+  header.storage.format_version_id = 1;
+  header.chunk_count = 50;
+  header.column_count = 3;
+  header.row_count = row_count;
+  header.chunk_ids = chunk_ids;
+  header.chunk_offset_ends = chunk_offset_ends;
+  
+  (void) header;
+
+  std::ofstream chunk_file;
+  chunk_file.open("test_chunk.bin", std::ios::out | std::ios::binary | std::ios::app);
+  chunk_file.write(reinterpret_cast<char*>(&header), sizeof(file_header));
+  chunk_file.close();
+
   write_chunk(dictionary_chunk, chunk_name);
   const auto mapped_chunk = map_chunk(chunk_name, segment_count);
 

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,74 +1,118 @@
 #include <fstream>
 
 #include "types.hpp"
+#include "storage/value_segment.hpp"
+#include "storage/chunk.hpp"
+#include "storage/chunk_encoder.hpp"
+
+
 
 using namespace hyrise;  // NOLINT
 
 struct file_format {
   uint16_t storage_format_version_id;
   uint8_t chunk_count;
-  std::vector<ChunkID> chunk_ids;
-  std::vector<ChunkOffset> chunk_offset_ends;
-  std::vector<char> chunks;
+  std::array<ChunkID, 50> chunk_ids;
+  std::array<ChunkOffset, 50> chunk_offset_ends;
 };
+
+struct chunk_header {
+  ColumnID segment_count;
+  ChunkOffset row_count;
+  std::vector<DataType> data_types;
+};
+
+chunk_header create_chunk_header(const std::shared_ptr<Chunk> chunk) {
+  auto result = chunk_header{};
+
+  result.segment_count = chunk->column_count();
+  result.row_count = chunk->size();
+
+  for (auto chunk_index = ColumnID{0}; chunk_index < result.segment_count; ++chunk_index) {
+    const auto segment = chunk->get_segment(chunk_index);
+    result.data_types.emplace_back(segment->data_type());
+  }
+
+  return result;
+}
+
 
 size_t get_file_size(std::string filename) {
   std::ifstream in_file(filename, std::ios::binary);
-  Assert(in_file, "File does not exist you dump fuck!");
+  Assert(in_file, "File does not exist you lovely human being!");
   in_file.seekg(0, std::ios::end);
   return in_file.tellg();
 }
 
-int main() {
-  file_format test;
-  test.storage_format_version_id = 65535;
-  test.chunk_count = 7;
-  test.chunks.emplace_back('i');
-  test.chunks.emplace_back('i');
-  test.chunks.emplace_back('i');
-  test.chunks.emplace_back('i');
-  test.chunks.emplace_back('i');
-  test.chunks.emplace_back('i');
-  test.chunks.emplace_back('i');
-  test.chunk_ids.emplace_back(0);
-  test.chunk_ids.emplace_back(1);
-  test.chunk_ids.emplace_back(2);
-  test.chunk_ids.emplace_back(3);
-  test.chunk_ids.emplace_back(4);
-  test.chunk_ids.emplace_back(5);
-  test.chunk_ids.emplace_back(6);
-  test.chunk_offset_ends.emplace_back(42);
+file_format create_header_for_chunk(const std::vector<std::shared_ptr<Chunk>>& chunks) {
+  auto result = file_format{};
+  
+  result.storage_format_version_id = 0;
+  result.chunk_count = chunks.size();
 
-  std::ofstream wf("test.bin", std::ios::out | std::ios::binary);
-  Assert(wf, "Cannot open file!");
-
-  wf.write((char*) &test.storage_format_version_id, sizeof(test.storage_format_version_id));
-  wf.write((char*) &test.chunk_count, sizeof(test.chunk_count));
-  wf.write((char*) test.chunk_ids.data(), sizeof(test.chunk_ids[0]) * test.chunk_ids.size());
-  wf.write((char*) test.chunk_offset_ends.data(), sizeof(test.chunk_offset_ends[0] * test.chunk_offset_ends.size()));
-  wf.write((char*) test.chunks.data(), sizeof(test.chunks[0]) * test.chunks.size());
-  wf.close();
-
-  std::ifstream rf("test.bin", std::ios::out | std::ios::binary);
-  Assert(rf, "Poooo");
-
-  const auto fsize = get_file_size("test.bin");
-  char* buffer = (char*)malloc(fsize);
-  (void)buffer;
-  rf.read((char*)buffer, fsize);
-
-
-  for (size_t i = 0; i < fsize; ++i) {
-    std::cout << buffer[i];
+  for (auto chunk_index = size_t{0}; chunk_index < result.chunk_count; ++chunk_index) {
+    result.chunk_ids[chunk_index] = chunk_index;
   }
 
-  auto x = uint16_t{0};
-  auto y = uint8_t{0};
+  return result;
+}
 
-  memcpy(&x, &buffer[0], sizeof(x));
-  memcpy(&y, &buffer[0], sizeof(y));
+int main() {
+  auto vs_int = std::make_shared<ValueSegment<int>>();
+  vs_int->append(4);
+  vs_int->append(6);
+  vs_int->append(3);
 
-  std::cout << x << "+++" << fsize << std::endl;
+  auto vs_str = std::make_shared<ValueSegment<pmr_string>>();
+  vs_str->append("Hello,");
+  vs_str->append("world");
+  vs_str->append("!");
+
+  auto ds_int = ChunkEncoder::encode_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
+  auto ds_str = ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
+
+  pmr_vector<std::shared_ptr<AbstractSegment>> empty_segments;
+  empty_segments.push_back(std::make_shared<ValueSegment<int32_t>>());
+  empty_segments.push_back(std::make_shared<ValueSegment<pmr_string>>());
+
+  auto chunk = std::make_shared<Chunk>(empty_segments);
+
+  file_format test;
+  std::cout << sizeof(test.chunk_ids) << std::endl;
+
+  // std::ofstream wf("test.bin", std::ios::out | std::ios::binary);
+  // // Assert(wf, "Cannot open file!");
+
+  // auto char_chunk = (char*) &chunk;
+  // wf.write(char_chunk, );
+
+  // wf.write((char*) &test.storage_format_version_id, sizeof(test.storage_format_version_id));
+  // wf.write((char*) &test.chunk_count, sizeof(test.chunk_count));
+  // wf.write((char*) test.chunk_ids.data(), sizeof(test.chunk_ids[0]) * test.chunk_ids.size());
+  // wf.write((char*) test.chunk_offset_ends.data(), sizeof(test.chunk_offset_ends[0] * test.chunk_offset_ends.size()));
+  // wf.write((char*) test.chunks.data(), sizeof(test.chunks[0]) * test.chunks.size());
+  // wf.close();
+
+  // std::ifstream rf("test.bin", std::ios::out | std::ios::binary);
+  // Assert(rf, "Poooo");
+
+  // const auto fsize = get_file_size("test.bin");
+  // char* buffer = (char*)malloc(fsize);
+  // (void)buffer;
+  // rf.read((char*)buffer, fsize);
+
+
+  // for (size_t i = 0; i < fsize; ++i) {
+  //   std::cout << buffer[i];
+  // }
+
+  // auto x = uint16_t{0};
+  // auto y = uint8_t{0};
+
+  // memcpy(&x, &buffer[0], sizeof(x));
+  // memcpy(&y, &buffer[0], sizeof(y));
+
+  // std::cout << x << "+++" << fsize << std::endl;
 
 
   // auto fformat = dynamic_cast<file_format*>(buffer);

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -334,9 +334,16 @@ int main() {
 
   auto chunk_ids = std::array<uint32_t, 50>();
   auto chunk_offset_ends = std::array<uint32_t, 50>();
+
+  auto offset = uint32_t{sizeof(file_header)};
   for (auto ind = uint32_t{0}; ind < 50; ++ind) {
+    // For efficiency, this could be taken out of the loop, but in reality,
+    // we would not have the same chunk written 50 times.
+    const auto segment_offsets = generate_segment_offset_ends(dictionary_chunk);
+    const auto chunk_size = uint32_t{segment_offsets.back()} + 1;
+    offset += chunk_size;
     chunk_ids[ind] = ind;
-    chunk_offset_ends[ind] = ind;
+    chunk_offset_ends[ind] = offset;
   }
 
   std::remove("test_chunk.bin"); //remove previously written file

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -220,7 +220,7 @@ void write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, const std::string& 
   const auto file_extension = ".bin";
   const auto filename = chunk_filename + file_extension;
   const auto segment_count = chunk->column_count();
-  const auto prior_filesize = std::filesystem::file_size(filename);
+  // const auto prior_filesize = std::filesystem::file_size(filename);
 
   auto offset_ends = std::vector<uint32_t>(segment_count);
 
@@ -229,7 +229,7 @@ void write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, const std::string& 
   chunk_file.open(filename, std::ios::out | std::ios::binary | std::ios::app);
   export_value(chunk_file, chunk->size());
   for (auto offset : segment_offset_ends) {
-    export_value(chunk_file, prior_filesize + offset);
+    export_value(chunk_file, offset);
   }
   chunk_file.close();
 

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,10 +1,82 @@
-#include <iostream>
+#include <fstream>
 
 #include "types.hpp"
 
 using namespace hyrise;  // NOLINT
 
+struct file_format {
+  uint16_t storage_format_version_id;
+  uint8_t chunk_count;
+  std::vector<ChunkID> chunk_ids;
+  std::vector<ChunkOffset> chunk_offset_ends;
+  std::vector<char> chunks;
+};
+
+size_t get_file_size(std::string filename) {
+  std::ifstream in_file(filename, std::ios::binary);
+  Assert(in_file, "File does not exist you dump fuck!");
+  in_file.seekg(0, std::ios::end);
+  return in_file.tellg();
+}
+
 int main() {
-  std::cout << "Hello world!!" << std::endl;
+  file_format test;
+  test.storage_format_version_id = 65535;
+  test.chunk_count = 7;
+  test.chunks.emplace_back('i');
+  test.chunks.emplace_back('i');
+  test.chunks.emplace_back('i');
+  test.chunks.emplace_back('i');
+  test.chunks.emplace_back('i');
+  test.chunks.emplace_back('i');
+  test.chunks.emplace_back('i');
+  test.chunk_ids.emplace_back(0);
+  test.chunk_ids.emplace_back(1);
+  test.chunk_ids.emplace_back(2);
+  test.chunk_ids.emplace_back(3);
+  test.chunk_ids.emplace_back(4);
+  test.chunk_ids.emplace_back(5);
+  test.chunk_ids.emplace_back(6);
+  test.chunk_offset_ends.emplace_back(42);
+
+  std::ofstream wf("test.bin", std::ios::out | std::ios::binary);
+  Assert(wf, "Cannot open file!");
+
+  wf.write((char*) &test.storage_format_version_id, sizeof(test.storage_format_version_id));
+  wf.write((char*) &test.chunk_count, sizeof(test.chunk_count));
+  wf.write((char*) test.chunk_ids.data(), sizeof(test.chunk_ids[0]) * test.chunk_ids.size());
+  wf.write((char*) test.chunk_offset_ends.data(), sizeof(test.chunk_offset_ends[0] * test.chunk_offset_ends.size()));
+  wf.write((char*) test.chunks.data(), sizeof(test.chunks[0]) * test.chunks.size());
+  wf.close();
+
+  std::ifstream rf("test.bin", std::ios::out | std::ios::binary);
+  Assert(rf, "Poooo");
+
+  const auto fsize = get_file_size("test.bin");
+  char* buffer = (char*)malloc(fsize);
+  (void)buffer;
+  rf.read((char*)buffer, fsize);
+
+
+  for (size_t i = 0; i < fsize; ++i) {
+    std::cout << buffer[i];
+  }
+
+  auto x = uint16_t{0};
+  auto y = uint8_t{0};
+
+  memcpy(&x, &buffer[0], sizeof(x));
+  memcpy(&y, &buffer[0], sizeof(y));
+
+  std::cout << x << "+++" << fsize << std::endl;
+
+
+  // auto fformat = dynamic_cast<file_format*>(buffer);
+
+  // std::cout << fsize << "+++" << sizeof(file_format) << std::endl;
+
+  // std::cout << loaded_data.storage_format_version_id << std::endl;// "+++" << loaded_data.chunk_count << std::endl;
+
+
   return 0;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -20,8 +20,6 @@ using namespace hyrise;  // NOLINT
 struct file_header {
   uint16_t storage_format_version_id;
   uint16_t chunk_count;
-  uint16_t column_count;
-  uint32_t row_count;
   std::array<uint32_t, 50> chunk_ids;
   std::array<uint32_t, 50> chunk_offset_ends;
 };
@@ -255,8 +253,8 @@ int main() {
   const auto dictionary_chunk = create_dictionary_segment_chunk(row_count, segment_count);
   const auto chunk_name = "test_chunk";
 
-  auto chunk_ids = std::vector<uint32_t>(50);
-  auto chunk_offset_ends = std::vector<uint32_t>(50);
+  auto chunk_ids = std::array<uint32_t, 50>();
+  auto chunk_offset_ends = std::array<uint32_t, 50>();
   for (auto ind = uint32_t{0}; ind < 50; ++ind) {
     chunk_ids[ind] = ind;
     chunk_offset_ends[ind] = ind;
@@ -267,13 +265,8 @@ int main() {
   file_header header;
   header.storage_format_version_id = 1;
   header.chunk_count = 50;
-  header.column_count = 3;
-  header.row_count = row_count;
   header.chunk_ids = chunk_ids;
   header.chunk_offset_ends = chunk_offset_ends;
-  
-  (void) header;
-  
 
   std::ofstream chunk_file;
   chunk_file.open("test_chunk.bin", std::ios::out | std::ios::binary | std::ios::app);

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -175,7 +175,7 @@ void write_dict_segment_to_disk(const std::shared_ptr<DictionarySegment<int>> se
 
 std::vector<uint32_t> generate_segment_offset_ends(const std::shared_ptr<Chunk> chunk) {
   const auto segment_count = chunk->column_count();
-  auto segment_offset_ends = std::vector<uint32_t>();
+  auto segment_offset_ends = std::vector<uint32_t>(segment_count);
 
   for (auto segment_index = size_t{0}; segment_index < segment_count; ++segment_index) {
     // 4 Byte Dictionary Size + 4 Byte Attribute Vector Size + 4 Compressed Vector Type ID
@@ -206,8 +206,12 @@ std::vector<uint32_t> generate_segment_offset_ends(const std::shared_ptr<Chunk> 
       default:
         Fail("Any other type should have been caught before.");
     }
-    
-    segment_offset_ends.emplace_back(offset_end);
+
+    if(segment_index == 0){
+      segment_offset_ends[segment_index] = offset_end;
+    } else {
+      segment_offset_ends[segment_index] = segment_offset_ends[segment_index-1] + offset_end;
+    }
   }
   return segment_offset_ends;
 }


### PR DESCRIPTION
This PR represents the current progress regarding the file format implementation. Fixes #79 

This is our current planning regarding the structure:

![FileFormat (1)](https://user-images.githubusercontent.com/38314662/215493523-5af45cfe-4c33-457c-8332-4c353c8a26d9.jpg)

The current state of the implementation is, that we're able to successfully write and then read the first chunk. Because of many hard-coded values in `map_chunk_from_disk` we are not able to adapt to the next chunk. Especially regarding the offsets we encountered some issues which led to the first chunk beginning at map index 148 instead of our calculated 102, which we think is because of some wrong storage of the segmentOffsets in the header of each chunk. 

As soon as we're able to start at the right offset for each following chunk, we should be able to correctly read the values from our written chunk.

Another problem is, that we currently use memcpy to read the values instead of mmap. This is because of our usage of vectors instead of spans, which we will fix in #83 

Please add comments when you add another change and use well documenting commit messages when you keep on working on this issue.
