### PR TITLE
WIP Moving Write from Playground to Storage Manager

### DIFF
--- a/src/lib/import_export/binary/binary_writer.hpp
+++ b/src/lib/import_export/binary/binary_writer.hpp
@@ -21,6 +21,7 @@ enum class CompressedVectorType : uint8_t;
 class BinaryWriter {
  public:
   static void write(const Table& table, const std::string& filename);
+  friend class StorageManager;
 
  private:
   /**

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -357,7 +357,9 @@ CompressedVectorTypeID infer_compressed_vector_type_id(
 void export_compact_vector(const pmr_compact_vector& values, std::string file_name) {
   //adapted to uint32_t format of later created map (see comment in `write_dict_segment_to_disk`)
   export_value(static_cast<uint32_t>(values.bits()), file_name);
+  std::ofstream ofstream(file_name, std::ios::binary | std::ios::app);
   ofstream.write(reinterpret_cast<const char*>(values.get()), static_cast<int64_t>(values.bytes()));
+  ofstream.close();
 }
 
 void export_compressed_vector(const CompressedVectorType type, const BaseCompressedVector& compressed_vector, 
@@ -424,7 +426,7 @@ void StorageManager::write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, con
     const auto abstract_segment = chunk->get_segment(static_cast<ColumnID>(static_cast<uint16_t>(segment_index)));
     const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(abstract_segment);
 
-    write_dict_segment_to_disk(dict_segment);
+    write_dict_segment_to_disk(dict_segment, file_name);
   }
 }
 
@@ -463,7 +465,7 @@ void StorageManager::persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> 
 
   for (auto chunk_index = uint32_t{0}; chunk_index < chunks.size(); ++chunk_index) {
     const auto chunk = chunks[chunk_index];
-    write_chunk_to_disk(chunk, chunk_segment_offset_ends[chunk_index]);
+    write_chunk_to_disk(chunk, chunk_segment_offset_ends[chunk_index], file_name);
   }
 
   // file_lock.release();

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -417,12 +417,6 @@ void StorageManager::write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, con
   header.row_count = chunk->size();
   header.segment_offset_ends = segment_offset_ends;
 
-  std::cout << "RowCount: " << header.row_count << std::endl;
-  for (const auto segment_offset_end : header.segment_offset_ends) {
-    std::cout << "+" << segment_offset_end;
-  }
-  std::cout << std::endl;
-
   export_value(FILESTREAM, header.row_count);
 
   for (const auto segment_offset_end : header.segment_offset_ends) {
@@ -433,19 +427,6 @@ void StorageManager::write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, con
   for (auto segment_index = size_t{0}; segment_index < segment_count; ++segment_index) {
     const auto abstract_segment = chunk->get_segment(static_cast<ColumnID>(static_cast<uint16_t>(segment_index)));
     const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(abstract_segment);
-
-    // debug print to verify written content
-    if (segment_index == 0) {
-      std::cout << "Dict: ";
-      for (auto i = size_t{0}; i < 20; ++i) {
-        std::cout << dict_segment->dictionary()->at(i) << " ";
-      }
-      std::cout << "\nAtt: ";
-      for (auto i = size_t{0}; i < 20; ++i) {
-        std::cout << dynamic_pointer_cast<const FixedWidthIntegerVector<uint16_t>>(dict_segment->attribute_vector())->data().at(i) << " ";
-      }
-      std::cout  << std::endl;
-    }
 
     write_dict_segment_to_disk(dict_segment);
   }

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -527,7 +527,7 @@ std::shared_ptr<Chunk> StorageManager::map_chunk_from_disk(const uint32_t chunk_
     const auto encoding_type = map[header_offset + segment_offset_end / 4 + 2];
 
     switch (encoding_type) {
-      case DICT_ENCODING_8_BIT: {
+      case dict_encoding_8_bit: {
         auto attribute_values = pmr_vector<uint8_t>(attribute_vector_size);
         memcpy(attribute_values.data(), &map[header_offset + segment_element_offset_index + 3 + dictionary_size],
                attribute_vector_size * sizeof(uint8_t));
@@ -537,7 +537,7 @@ std::shared_ptr<Chunk> StorageManager::map_chunk_from_disk(const uint32_t chunk_
         segments.emplace_back(dynamic_pointer_cast<AbstractSegment>(dictionary_segment));
         break;
       }
-      case DICT_ENCODING_16_BIT: {
+      case dict_encoding_16_bit: {
         auto attribute_values = pmr_vector<uint16_t>(attribute_vector_size);
         memcpy(attribute_values.data(), &map[header_offset + segment_element_offset_index + 3 + dictionary_size],
                attribute_vector_size * sizeof(uint16_t));

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -475,9 +475,7 @@ file_header StorageManager::read_file_header(std::string filename) {
   file_header file_header;
   auto fd = int32_t{};
 
-  Assert((fd = ((size_t) open(filename.c_str(), O_RDONLY)) >= 0), "Open error");
-  // You might wonder why it's doubled, but without the second call it doesn't work
-  fd = (size_t) open(filename.c_str(), O_RDONLY);
+  Assert((fd = open(filename.c_str(), O_RDONLY)) >= 0, "Open error");
   auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, FILE_HEADER_BYTES, PROT_READ, MAP_PRIVATE, fd, off_t{0}));
   Assert((map != MAP_FAILED), "Mapping Failed");
   close(fd);

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -549,7 +549,7 @@ std::shared_ptr<Chunk> StorageManager::map_chunk_from_disk(const uint32_t chunk_
     (void) encoding_type;
 
     switch (encoding_type) {
-      case DICT_ENCODING_8_BYTE: {
+      case DICT_ENCODING_8_BIT: {
         auto attribute_values = pmr_vector<uint8_t>(attribute_vector_size);
         memcpy(attribute_values.data(), &map[header_offset + segment_element_offset_index + 3 + dictionary_size],
                attribute_vector_size * sizeof(uint8_t));
@@ -559,7 +559,7 @@ std::shared_ptr<Chunk> StorageManager::map_chunk_from_disk(const uint32_t chunk_
         segments.emplace_back(dynamic_pointer_cast<AbstractSegment>(dictionary_segment));
         break;
       }
-      case DICT_ENCODING_16_BYTE: {
+      case DICT_ENCODING_16_BIT: {
         auto attribute_values = pmr_vector<uint16_t>(attribute_vector_size);
         memcpy(attribute_values.data(), &map[header_offset + segment_element_offset_index + 3 + dictionary_size],
                attribute_vector_size * sizeof(uint16_t));

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -483,8 +483,8 @@ chunk_header StorageManager::read_chunk_header(const std::string& filename, cons
 
   header.row_count = map[map_index];
 
-  for (auto header_index = size_t{1}; header_index < segment_count + 1; ++header_index) {
-    header.segment_offset_ends.emplace_back(map[header_index + map_index]);
+  for (auto segment_offset_index = size_t{0}; segment_offset_index < segment_count + 1; ++segment_offset_index) {
+    header.segment_offset_ends.emplace_back(map[segment_offset_index + map_index + 1]);
   }
 
   return header;

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -1,5 +1,7 @@
 #include "storage_manager.hpp"
 
+#include <sys/fcntl.h>
+#include <sys/mman.h>
 #include <memory>
 #include <string>
 #include <utility>
@@ -13,6 +15,11 @@
 #include "scheduler/job_task.hpp"
 #include "statistics/generate_pruning_statistics.hpp"
 #include "statistics/table_statistics.hpp"
+#include "storage/base_dictionary_segment.hpp"
+#include "storage/create_iterable_from_segment.hpp"
+#include "storage/dictionary_segment.hpp"
+#include "storage/dictionary_segment/dictionary_segment_iterable.hpp"
+#include "storage/value_segment.hpp"
 #include "utils/assert.hpp"
 #include "utils/meta_table_manager.hpp"
 
@@ -259,5 +266,257 @@ std::ostream& operator<<(std::ostream& stream, const StorageManager& storage_man
 
   return stream;
 }
+
+uint32_t byte_index(uint32_t element_index, size_t element_size) {
+  return element_index * element_size;
+}
+
+uint32_t element_index(uint32_t byte_index, size_t element_size) {
+  return byte_index / element_size;
+}
+
+std::vector<uint32_t> StorageManager::generate_segment_offset_ends(const std::shared_ptr<Chunk> chunk) {
+  const auto segment_count = chunk->column_count();
+  auto segment_offset_ends = std::vector<uint32_t>(segment_count);
+
+  auto offset_end = CHUNK_HEADER_BYTES;
+  for (auto segment_index = size_t{0}; segment_index < segment_count; ++segment_index) {
+    offset_end += SEGMENT_HEADER_BYTES;
+
+    const auto abstract_segment = chunk->get_segment(static_cast<ColumnID>(static_cast<uint16_t>(segment_index)));
+    const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(abstract_segment);
+
+    offset_end += byte_index(dict_segment->dictionary()->size(), 4);
+
+    const auto attribute_vector = dict_segment->attribute_vector();
+    const auto attribute_vector_type = attribute_vector->type();
+
+    switch (attribute_vector_type) {
+      case CompressedVectorType::FixedWidthInteger4Byte:
+        offset_end += byte_index(attribute_vector->size(), 4);
+        break;
+      case CompressedVectorType::FixedWidthInteger2Byte:
+        offset_end += byte_index(attribute_vector->size(), 2);
+        break;
+      case CompressedVectorType::FixedWidthInteger1Byte:
+        offset_end += attribute_vector->size();
+        break;
+      case CompressedVectorType::BitPacking:
+        offset_end += 4;
+        offset_end += dynamic_cast<const BitPackingVector&>(*attribute_vector).data().bytes();
+        break;
+      default:
+        Fail("Any other type should have been caught before.");
+    }
+
+    segment_offset_ends[segment_index] = offset_end;
+  }
+  return segment_offset_ends;
+}
+
+void StorageManager::prepare_filestream() {
+  // std::remove(FILENAME);
+  FILESTREAM.open(FILENAME, std::ios::out | std::ios::binary | std::ios::app);
+}
+
+void StorageManager::end_filestream() {
+  FILESTREAM.close();
+}
+
+/*
+ * Copied binary writing functions from `binary_writer.cpp`
+ */
+
+template <typename T>
+void export_value(std::ofstream& ofstream, const T& value) {
+  ofstream.write(reinterpret_cast<const char*>(&value), sizeof(T));
+}
+
+template <typename T, typename Alloc>
+void export_values(std::ofstream& ofstream, const std::vector<T, Alloc>& values) {
+  ofstream.write(reinterpret_cast<const char*>(values.data()), values.size() * sizeof(T));
+}
+
+template <typename T>
+CompressedVectorTypeID infer_compressed_vector_type_id(
+    const AbstractEncodedSegment& abstract_encoded_segment) {
+  uint8_t compressed_vector_type_id = 0u;
+  resolve_encoded_segment_type<T>(abstract_encoded_segment, [&compressed_vector_type_id](auto& typed_segment) {
+    const auto compressed_vector_type = typed_segment.compressed_vector_type();
+    Assert(compressed_vector_type, "Expected Segment to use vector compression");
+    switch (*compressed_vector_type) {
+      case CompressedVectorType::FixedWidthInteger4Byte:
+      case CompressedVectorType::FixedWidthInteger2Byte:
+      case CompressedVectorType::FixedWidthInteger1Byte:
+      case CompressedVectorType::BitPacking:
+        compressed_vector_type_id = static_cast<uint8_t>(*compressed_vector_type);
+        break;
+      default:
+        Fail("Export of specified CompressedVectorType is not yet supported");
+    }
+  });
+  return compressed_vector_type_id;
+}
+
+// needed for attribute vector which is stored in a compact manner
+void export_compact_vector(std::ofstream& ofstream, const pmr_compact_vector& values) {
+  //adapted to uint32_t format of later created map (see comment in `write_dict_segment_to_disk`)
+  export_value(ofstream, static_cast<uint32_t>(values.bits()));
+  ofstream.write(reinterpret_cast<const char*>(values.get()), static_cast<int64_t>(values.bytes()));
+}
+
+void export_compressed_vector(std::ofstream& ofstream, const CompressedVectorType type,
+                              const BaseCompressedVector& compressed_vector) {
+  switch (type) {
+    case CompressedVectorType::FixedWidthInteger4Byte:
+      export_values(ofstream, dynamic_cast<const FixedWidthIntegerVector<uint32_t>&>(compressed_vector).data());
+      return;
+    case CompressedVectorType::FixedWidthInteger2Byte:
+      export_values(ofstream, dynamic_cast<const FixedWidthIntegerVector<uint16_t>&>(compressed_vector).data());
+      return;
+    case CompressedVectorType::FixedWidthInteger1Byte:
+      export_values(ofstream, dynamic_cast<const FixedWidthIntegerVector<uint8_t>&>(compressed_vector).data());
+      return;
+    case CompressedVectorType::BitPacking:
+      export_compact_vector(ofstream, dynamic_cast<const BitPackingVector&>(compressed_vector).data());
+      return;
+    default:
+      Fail("Any other type should have been caught before.");
+  }
+}
+
+void StorageManager::write_dict_segment_to_disk(const std::shared_ptr<DictionarySegment<int>> segment) {
+  /*
+   * Write dict segment to given file using the following format:
+   * 1. Number of elements in dictionary
+   * 2. Number of elements in attribute_vector
+   * 3. AttributeVectorCompressionID aka. size of int used in attribute vector
+   * 3. Dictionary values
+   * 4. Attribute_vector values
+   *
+   * For this exercise we assume an <int>-DictionarySegment with an FixedWidthIntegerVector<uint16_t> attribute_vector.
+   * As a next step we should use the AttributeVectorCompressionID to define the type of the FixedWidthIntegerVector
+   * and perhaps also write out the type of the DictionarySegment.
+   */
+
+  //TODO: Should this be continued?
+  // We will later mmap to an uint32_t vector/array. Therefore, we store all metadata points as uint32_t.
+  // This wastes up to three bytes of compression per metadata point but makes mapping much easier.
+  export_value(FILESTREAM, static_cast<uint32_t>(segment->dictionary()->size()));
+  export_value(FILESTREAM, static_cast<uint32_t>(segment->attribute_vector()->size()));
+
+  const auto compressed_vector_type_id = static_cast<uint32_t>(infer_compressed_vector_type_id<int>(*segment));
+  export_value(FILESTREAM, compressed_vector_type_id);
+
+  export_values<int32_t>(FILESTREAM, *segment->dictionary());
+  export_compressed_vector(FILESTREAM, *segment->compressed_vector_type(),
+                           *segment->attribute_vector());
+}
+
+void StorageManager::write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, const std::vector<uint32_t> segment_offset_ends) {
+  chunk_header header;
+  header.row_count = chunk->size();
+  header.segment_offset_ends = segment_offset_ends;
+
+  std::cout << "RowCount: " << header.row_count << std::endl;
+  for (const auto segment_offset_end : header.segment_offset_ends) {
+    std::cout << "+" << segment_offset_end;
+  }
+  std::cout << std::endl;
+
+  export_value(FILESTREAM, header.row_count);
+
+  for (const auto segment_offset_end : header.segment_offset_ends) {
+    export_value(FILESTREAM, segment_offset_end);
+  }
+
+  const auto segment_count = chunk->column_count();
+  for (auto segment_index = size_t{0}; segment_index < segment_count; ++segment_index) {
+    const auto abstract_segment = chunk->get_segment(static_cast<ColumnID>(static_cast<uint16_t>(segment_index)));
+    const auto dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(abstract_segment);
+
+    // debug print to verify written content
+    if (segment_index == 0) {
+      std::cout << "Dict: ";
+      for (auto i = size_t{0}; i < 20; ++i) {
+        std::cout << dict_segment->dictionary()->at(i) << " ";
+      }
+      std::cout << "\nAtt: ";
+      for (auto i = size_t{0}; i < 20; ++i) {
+        std::cout << dynamic_pointer_cast<const FixedWidthIntegerVector<uint16_t>>(dict_segment->attribute_vector())->data().at(i) << " ";
+      }
+      std::cout  << std::endl;
+    }
+
+    write_dict_segment_to_disk(dict_segment);
+  }
+}
+
+void StorageManager::persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> chunks) {
+  // file_lock.acquire();
+
+  auto chunk_segment_offset_ends = std::vector<std::vector<uint32_t>>(StorageManager::CHUNK_COUNT);
+  auto chunk_offset_ends = std::array<uint32_t, StorageManager::CHUNK_COUNT>();
+  auto chunk_ids = std::array<uint32_t, StorageManager::CHUNK_COUNT>();
+
+  auto offset = uint32_t{sizeof(file_header)};
+  for (auto chunk_index = uint32_t{0}; chunk_index < chunks.size(); ++chunk_index) {
+    const auto segment_offset_ends = generate_segment_offset_ends(chunks[chunk_index]);
+    offset += segment_offset_ends.back();
+
+    chunk_segment_offset_ends[chunk_index] = segment_offset_ends;
+    chunk_offset_ends[chunk_index] = offset;
+  }
+  // Fill all offset fields, that are not used with 0s.
+  for (auto rest_chunk_index = chunks.size(); rest_chunk_index < StorageManager::CHUNK_COUNT; ++rest_chunk_index) {
+    chunk_offset_ends[rest_chunk_index] = uint32_t{0};
+  }
+
+  // TODO(everyone): Find, how to get the actual chunk id.
+  for (auto index = uint32_t{0}; index < StorageManager::CHUNK_COUNT; ++index) {
+    chunk_ids[index] = index;
+  }
+
+  file_header fh;
+  fh.storage_format_version_id = 2;
+  fh.chunk_count = static_cast<uint16_t>(chunks.size());
+  fh.chunk_ids = chunk_ids;
+  fh.chunk_offset_ends = chunk_offset_ends;
+
+  export_value<file_header>(StorageManager::FILESTREAM, fh);
+
+  for (auto chunk_index = uint32_t{0}; chunk_index < chunks.size(); ++chunk_index) {
+    const auto chunk = chunks[chunk_index];
+    write_chunk_to_disk(chunk, chunk_segment_offset_ends[chunk_index]);
+  }
+
+  // file_lock.release();
+}
+
+file_header StorageManager::read_file_header(std::string filename) {
+  file_header file_header;
+
+  auto fd = int32_t{};
+  Assert((fd = open(filename.c_str(), O_RDONLY) >= 0), "Open error");
+  auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, sizeof(file_header), PROT_READ, MAP_PRIVATE, fd, off_t{0}));
+  Assert((map != MAP_FAILED), "Mapping Failed");
+  close(fd);
+
+  file_header.storage_format_version_id = map[0];
+  file_header.chunk_count = map[1];
+
+  const auto fixed_mapped_element_count = 2;
+
+  for (auto header_index = size_t{0}; header_index < file_header.chunk_count; ++header_index) {
+    file_header.chunk_ids[header_index] = map[fixed_mapped_element_count + header_index];
+    file_header.chunk_offset_ends[header_index] = map[fixed_mapped_element_count + StorageManager::CHUNK_COUNT + header_index];
+  }
+
+  return file_header;
+}
+
+
+
+
 
 }  // namespace hyrise

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -361,7 +361,7 @@ void export_compressed_vector(const CompressedVectorType type, const BaseCompres
 }
 
 void StorageManager::write_dict_segment_to_disk(const std::shared_ptr<DictionarySegment<int>> segment,
-                                                std::string file_name) {
+                                                const std::string& file_name) {
   /*
    * For a description of how dictionary segments look, see the following PR:
    *    https://github.com/hyrise-mp-22-23/hyrise/pull/94
@@ -376,8 +376,8 @@ void StorageManager::write_dict_segment_to_disk(const std::shared_ptr<Dictionary
   export_compressed_vector(*segment->compressed_vector_type(), *segment->attribute_vector(), file_name);
 }
 
-void StorageManager::write_chunk_to_disk(const std::shared_ptr<Chunk> chunk,
-                                         const std::vector<uint32_t> segment_offset_ends, std::string file_name) {
+void StorageManager::write_chunk_to_disk(const std::shared_ptr<Chunk>& chunk,
+                                         const std::vector<uint32_t>& segment_offset_ends, const std::string& file_name) {
   chunk_header header;
   header.row_count = chunk->size();
   header.segment_offset_ends = segment_offset_ends;
@@ -397,7 +397,7 @@ void StorageManager::write_chunk_to_disk(const std::shared_ptr<Chunk> chunk,
   }
 }
 
-void StorageManager::persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> chunks, std::string file_name) {
+void StorageManager::persist_chunks_to_disk(const std::vector<std::shared_ptr<Chunk>>& chunks, const std::string& file_name) {
   /*
     TODO(everyone): Think about a proper implementation of a locking method. Each written file needs to be
     locked prior to writing (and released afterwards). It was decided to use the mutex class by cpp.
@@ -418,8 +418,8 @@ void StorageManager::persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> 
     chunk_offset_ends[chunk_index] = offset;
   }
   // Fill all offset fields, that are not used with 0s.
-  for (auto rest_chunk_index = chunks.size(); rest_chunk_index < StorageManager::CHUNK_COUNT; ++rest_chunk_index) {
-    chunk_offset_ends[rest_chunk_index] = uint32_t{0};
+  for (auto chunk_index = chunks.size(); chunk_index < StorageManager::CHUNK_COUNT; ++chunk_index) {
+    chunk_offset_ends[chunk_index] = uint32_t{0};
   }
 
   // TODO(everyone): Find, how to get the actual chunk id.
@@ -443,7 +443,7 @@ void StorageManager::persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> 
   // file_lock.release();
 }
 
-file_header StorageManager::read_file_header(std::string filename) {
+file_header StorageManager::read_file_header(const std::string& filename) {
   file_header file_header;
   auto fd = int32_t{};
 
@@ -467,7 +467,7 @@ file_header StorageManager::read_file_header(std::string filename) {
   return file_header;
 }
 
-chunk_header StorageManager::read_chunk_header(const std::string filename, const uint32_t segment_count,
+chunk_header StorageManager::read_chunk_header(const std::string& filename, const uint32_t segment_count,
                                                const uint32_t chunk_offset_begin) {
   // TODO: Remove need to map the whole file.
   chunk_header header;
@@ -490,7 +490,7 @@ chunk_header StorageManager::read_chunk_header(const std::string filename, const
   return header;
 }
 
-std::shared_ptr<Chunk> StorageManager::map_chunk_from_disk(const uint32_t chunk_offset_end, const std::string filename,
+std::shared_ptr<Chunk> StorageManager::map_chunk_from_disk(const uint32_t chunk_offset_end, const std::string& filename,
                                                            const uint32_t segment_count) {
   auto segments = pmr_vector<std::shared_ptr<AbstractSegment>>{};
 
@@ -500,7 +500,7 @@ std::shared_ptr<Chunk> StorageManager::map_chunk_from_disk(const uint32_t chunk_
   const auto file_bytes = std::filesystem::file_size(filename);
 
   // TODO: Remove unneccesary map on whole file
-  auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, file_bytes, PROT_READ, MAP_PRIVATE, fd, off_t{0}));
+  const auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, file_bytes, PROT_READ, MAP_PRIVATE, fd, off_t{0}));
   Assert((map != MAP_FAILED), "Mapping of File Failed.");
   close(fd);
 

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -475,7 +475,9 @@ file_header StorageManager::read_file_header(std::string filename) {
   file_header file_header;
   auto fd = int32_t{};
 
-  Assert((fd = open(filename.c_str(), O_RDONLY) >= 0), "Open error");
+  Assert((fd = ((size_t) open(filename.c_str(), O_RDONLY)) >= 0), "Open error");
+  // You might wonder why it's doubled, but without the second call it doesn't work
+  fd = (size_t) open(filename.c_str(), O_RDONLY);
   auto* map = reinterpret_cast<uint32_t*>(mmap(NULL, FILE_HEADER_BYTES, PROT_READ, MAP_PRIVATE, fd, off_t{0}));
   Assert((map != MAP_FAILED), "Mapping Failed");
   close(fd);

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -315,7 +315,6 @@ std::vector<uint32_t> StorageManager::generate_segment_offset_ends(const std::sh
 }
 
 void StorageManager::prepare_filestream() {
-  // std::remove(FILENAME);
   FILESTREAM.open(FILENAME, std::ios::out | std::ios::binary | std::ios::app);
 }
 

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -8,6 +8,7 @@
 #include <shared_mutex>
 #include <string>
 #include <vector>
+#include <fstream>
 
 #include "storage/chunk_encoder.hpp"
 #include "lqp_view.hpp"

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -8,8 +8,6 @@
 #include <shared_mutex>
 #include <string>
 #include <vector>
-#include <semaphore>
-#include <fstream>
 
 #include "storage/chunk_encoder.hpp"
 #include "lqp_view.hpp"
@@ -35,7 +33,7 @@ struct chunk_header {
   std::vector<uint32_t> segment_offset_ends;
 };
 
-enum ENCODING_TYPE {NO_ENCODING = 0, DICT_ENCODING_8_BYTE = 1, DICT_ENCODING_16_BYTE = 2};
+enum ENCODING_TYPE {NO_ENCODING = 0, DICT_ENCODING_8_BIT = 1, DICT_ENCODING_16_BIT = 2};
 
 // The StorageManager is a class that maintains all tables
 // by mapping table names to table instances.
@@ -85,7 +83,7 @@ class StorageManager : public Noncopyable {
   file_header read_file_header(std::string filename);
   std::shared_ptr<Chunk> map_chunk_from_disk(const uint32_t chunk_offset_end, const std::string filename, const uint32_t segment_count);
 
-  uint32_t get_max_chunk_count() {
+  uint32_t get_max_chunk_count_per_file() {
     return CHUNK_COUNT;
   }
   uint32_t get_storage_format_version_id() {
@@ -109,8 +107,8 @@ class StorageManager : public Noncopyable {
 
   // Fileformat constants
   // File Header
-  uint32_t FORMAT_VERSION_ID_BYTES = 2;
-  uint32_t CHUNK_COUNT_BYTES = 2;
+  uint32_t FORMAT_VERSION_ID_BYTES = 4;
+  uint32_t CHUNK_COUNT_BYTES = 4;
   uint32_t CHUNK_ID_BYTES = 4;
   uint32_t CHUNK_OFFSET_BYTES = 4;
   uint32_t FILE_HEADER_BYTES = FORMAT_VERSION_ID_BYTES + CHUNK_COUNT_BYTES + CHUNK_COUNT * CHUNK_ID_BYTES + CHUNK_COUNT * CHUNK_OFFSET_BYTES;

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -22,11 +22,13 @@ namespace hyrise {
 class Table;
 class AbstractLQPNode;
 
+const auto MAX_CHUNK_COUNT = uint8_t{50};
+
 struct file_header {
   uint32_t storage_format_version_id;
   uint32_t chunk_count;
-  std::array<uint32_t, 50> chunk_ids;
-  std::array<uint32_t, 50> chunk_offset_ends;
+  std::array<uint32_t, MAX_CHUNK_COUNT> chunk_ids;
+  std::array<uint32_t, MAX_CHUNK_COUNT> chunk_offset_ends;
 };
 
 struct chunk_header {

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -88,20 +88,11 @@ class StorageManager : public Noncopyable {
   tbb::concurrent_unordered_map<std::string, std::shared_ptr<LQPView>> _views{INITIAL_MAP_SIZE};
   tbb::concurrent_unordered_map<std::string, std::shared_ptr<PreparedPlan>> _prepared_plans{INITIAL_MAP_SIZE};
 
-  void prepare_filestream();
-  void persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> chunks);
-  void end_filestream();
+  void persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> chunks, std::string file_name);
   file_header read_file_header(std::string filename);
 
  private:
   static const uint32_t CHUNK_COUNT = 50;
-  uint32_t COLUMN_COUNT = uint32_t{23};
-  uint32_t ROW_COUNT = uint32_t{65'000};
-
-  std::string FILENAME = "z_binary_test.bin";
-  std::ofstream FILESTREAM;
-  // std::counting_semaphore<1> file_lock;
-  uint32_t CREATE_COUNT = uint32_t{4};
 
   // Fileformat constants
   // File Header
@@ -114,7 +105,9 @@ class StorageManager : public Noncopyable {
   // Chunk Header
   uint32_t ROW_COUNT_BYTES = 4;
   uint32_t SEGMENT_OFFSET_BYTES = 4;
-  uint32_t CHUNK_HEADER_BYTES = ROW_COUNT_BYTES + COLUMN_COUNT * SEGMENT_OFFSET_BYTES;
+  uint32_t CHUNK_HEADER_BYTES(uint32_t COLUMN_COUNT) {
+    return ROW_COUNT_BYTES + COLUMN_COUNT * SEGMENT_OFFSET_BYTES;
+  }
 
   // Segment Header
   uint32_t DICTIONARY_SIZE_BYTES = 4;

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -2,17 +2,17 @@
 
 #include <tbb/concurrent_unordered_map.h>
 
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <shared_mutex>
 #include <string>
 #include <vector>
-#include <fstream>
 
-#include "storage/chunk_encoder.hpp"
 #include "lqp_view.hpp"
 #include "prepared_plan.hpp"
+#include "storage/chunk_encoder.hpp"
 #include "types.hpp"
 
 #include "storage/dictionary_segment.hpp"
@@ -36,7 +36,7 @@ struct chunk_header {
   std::vector<uint32_t> segment_offset_ends;
 };
 
-enum ENCODING_TYPE {NO_ENCODING = 0, DICT_ENCODING_8_BIT = 1, DICT_ENCODING_16_BIT = 2};
+enum ENCODING_TYPE { NO_ENCODING = 0, DICT_ENCODING_8_BIT = 1, DICT_ENCODING_16_BIT = 2 };
 
 // The StorageManager is a class that maintains all tables
 // by mapping table names to table instances.
@@ -84,11 +84,13 @@ class StorageManager : public Noncopyable {
 
   // These functions are for the moment public, to test them properly.
   file_header read_file_header(std::string filename);
-  std::shared_ptr<Chunk> map_chunk_from_disk(const uint32_t chunk_offset_end, const std::string filename, const uint32_t segment_count);
+  std::shared_ptr<Chunk> map_chunk_from_disk(const uint32_t chunk_offset_end, const std::string filename,
+                                             const uint32_t segment_count);
 
   uint32_t get_max_chunk_count_per_file() {
     return CHUNK_COUNT;
   }
+
   uint32_t get_storage_format_version_id() {
     return STORAGE_FORMAT_VERSION_ID;
   }
@@ -114,11 +116,13 @@ class StorageManager : public Noncopyable {
   uint32_t CHUNK_COUNT_BYTES = 4;
   uint32_t CHUNK_ID_BYTES = 4;
   uint32_t CHUNK_OFFSET_BYTES = 4;
-  uint32_t FILE_HEADER_BYTES = FORMAT_VERSION_ID_BYTES + CHUNK_COUNT_BYTES + CHUNK_COUNT * CHUNK_ID_BYTES + CHUNK_COUNT * CHUNK_OFFSET_BYTES;
+  uint32_t FILE_HEADER_BYTES =
+      FORMAT_VERSION_ID_BYTES + CHUNK_COUNT_BYTES + CHUNK_COUNT * CHUNK_ID_BYTES + CHUNK_COUNT * CHUNK_OFFSET_BYTES;
 
   // Chunk Header
   uint32_t ROW_COUNT_BYTES = 4;
   uint32_t SEGMENT_OFFSET_BYTES = 4;
+
   uint32_t CHUNK_HEADER_BYTES(uint32_t COLUMN_COUNT) {
     return ROW_COUNT_BYTES + COLUMN_COUNT * SEGMENT_OFFSET_BYTES;
   }
@@ -129,11 +133,13 @@ class StorageManager : public Noncopyable {
   uint32_t COMPRESSED_VECTOR_TYPE_ID_BYTES = 4;
   uint32_t SEGMENT_HEADER_BYTES = DICTIONARY_SIZE_BYTES + ELEMENT_COUNT_BYTES + COMPRESSED_VECTOR_TYPE_ID_BYTES;
 
-  chunk_header read_chunk_header(const std::string filename, const uint32_t segment_count, const uint32_t chunk_offset_begin);
+  chunk_header read_chunk_header(const std::string filename, const uint32_t segment_count,
+                                 const uint32_t chunk_offset_begin);
 
   std::vector<uint32_t> generate_segment_offset_ends(const std::shared_ptr<Chunk> chunk);
   void write_dict_segment_to_disk(const std::shared_ptr<DictionarySegment<int>> segment, std::string file_name);
-  void write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, const std::vector<uint32_t> segment_offset_ends, std::string file_name);
+  void write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, const std::vector<uint32_t> segment_offset_ends,
+                           std::string file_name);
 };
 
 std::ostream& operator<<(std::ostream& stream, const StorageManager& storage_manager);

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -94,33 +94,33 @@ class StorageManager : public Noncopyable {
   file_header read_file_header(std::string filename);
 
  private:
-  static const int CHUNK_COUNT = 50;
-  const uint32_t COLUMN_COUNT = uint32_t{23};
-  const uint32_t ROW_COUNT = uint32_t{65'000};
+  static const uint32_t CHUNK_COUNT = 50;
+  uint32_t COLUMN_COUNT = uint32_t{23};
+  uint32_t ROW_COUNT = uint32_t{65'000};
 
   std::string FILENAME = "z_binary_test.bin";
   std::ofstream FILESTREAM;
   // std::counting_semaphore<1> file_lock;
-  const uint32_t CREATE_COUNT = uint32_t{4};
+  uint32_t CREATE_COUNT = uint32_t{4};
 
   // Fileformat constants
   // File Header
-  const uint32_t FORMAT_VERSION_ID_BYTES = 2;
-  const uint32_t CHUNK_COUNT_BYTES = 2;
-  const uint32_t CHUNK_ID_BYTES = 4;
-  const uint32_t CHUNK_OFFSET_BYTES = 4;
-  const uint32_t FILE_HEADER_BYTES = FORMAT_VERSION_ID_BYTES + CHUNK_COUNT_BYTES + CHUNK_COUNT * CHUNK_ID_BYTES + CHUNK_COUNT * CHUNK_OFFSET_BYTES;
+  uint32_t FORMAT_VERSION_ID_BYTES = 2;
+  uint32_t CHUNK_COUNT_BYTES = 2;
+  uint32_t CHUNK_ID_BYTES = 4;
+  uint32_t CHUNK_OFFSET_BYTES = 4;
+  uint32_t FILE_HEADER_BYTES = FORMAT_VERSION_ID_BYTES + CHUNK_COUNT_BYTES + CHUNK_COUNT * CHUNK_ID_BYTES + CHUNK_COUNT * CHUNK_OFFSET_BYTES;
 
   // Chunk Header
-  const uint32_t ROW_COUNT_BYTES = 4;
-  const uint32_t SEGMENT_OFFSET_BYTES = 4;
-  const uint32_t CHUNK_HEADER_BYTES = ROW_COUNT_BYTES + COLUMN_COUNT * SEGMENT_OFFSET_BYTES;
+  uint32_t ROW_COUNT_BYTES = 4;
+  uint32_t SEGMENT_OFFSET_BYTES = 4;
+  uint32_t CHUNK_HEADER_BYTES = ROW_COUNT_BYTES + COLUMN_COUNT * SEGMENT_OFFSET_BYTES;
 
   // Segment Header
-  const uint32_t DICTIONARY_SIZE_BYTES = 4;
-  const uint32_t ELEMENT_COUNT_BYTES = 4;
-  const uint32_t COMPRESSED_VECTOR_TYPE_ID_BYTES = 4;
-  const uint32_t SEGMENT_HEADER_BYTES = DICTIONARY_SIZE_BYTES + ELEMENT_COUNT_BYTES + COMPRESSED_VECTOR_TYPE_ID_BYTES;
+  uint32_t DICTIONARY_SIZE_BYTES = 4;
+  uint32_t ELEMENT_COUNT_BYTES = 4;
+  uint32_t COMPRESSED_VECTOR_TYPE_ID_BYTES = 4;
+  uint32_t SEGMENT_HEADER_BYTES = DICTIONARY_SIZE_BYTES + ELEMENT_COUNT_BYTES + COMPRESSED_VECTOR_TYPE_ID_BYTES;
 
   std::vector<uint32_t> generate_segment_offset_ends(const std::shared_ptr<Chunk> chunk);
   void write_dict_segment_to_disk(const std::shared_ptr<DictionarySegment<int>> segment);

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -116,8 +116,8 @@ class StorageManager : public Noncopyable {
   uint32_t SEGMENT_HEADER_BYTES = DICTIONARY_SIZE_BYTES + ELEMENT_COUNT_BYTES + COMPRESSED_VECTOR_TYPE_ID_BYTES;
 
   std::vector<uint32_t> generate_segment_offset_ends(const std::shared_ptr<Chunk> chunk);
-  void write_dict_segment_to_disk(const std::shared_ptr<DictionarySegment<int>> segment);
-  void write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, const std::vector<uint32_t> segment_offset_ends);
+  void write_dict_segment_to_disk(const std::shared_ptr<DictionarySegment<int>> segment, std::string file_name);
+  void write_chunk_to_disk(const std::shared_ptr<Chunk> chunk, const std::vector<uint32_t> segment_offset_ends, std::string file_name);
 };
 
 std::ostream& operator<<(std::ostream& stream, const StorageManager& storage_manager);

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -35,7 +35,7 @@ struct chunk_header {
   std::vector<uint32_t> segment_offset_ends;
 };
 
-enum ENCODING_TYPE { NO_ENCODING = 0, DICT_ENCODING_8_BIT = 1, DICT_ENCODING_16_BIT = 2, DICT_ENCODING_32_BIT = 3, DICT_ENCODING_BITPACKING = 4 };
+enum encoding_types { no_encoding = 0, dict_encoding_8_bit = 1, dict_encoding_16_bit = 2, dict_encoding_32_bit = 3, dict_encoding_bitpacking = 4 };
 
 // The StorageManager is a class that maintains all tables
 // by mapping table names to table instances.

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -77,6 +77,19 @@ class StorageManager : public Noncopyable {
   // For debugging purposes mostly, dump all tables as csv
   void export_all_tables_as_csv(const std::string& path);
 
+  void persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> chunks, std::string file_name);
+
+  // These functions are for the moment public, to test them properly.
+  file_header read_file_header(std::string filename);
+  std::shared_ptr<Chunk> map_chunk_from_disk(const uint32_t chunk_offset_end, const std::string filename, const uint32_t segment_count);
+
+  uint32_t get_max_chunk_count() {
+    return CHUNK_COUNT;
+  }
+  uint32_t get_storage_format_version_id() {
+    return STORAGE_FORMAT_VERSION_ID;
+  }
+
  protected:
   StorageManager() = default;
   friend class Hyrise;
@@ -88,11 +101,9 @@ class StorageManager : public Noncopyable {
   tbb::concurrent_unordered_map<std::string, std::shared_ptr<LQPView>> _views{INITIAL_MAP_SIZE};
   tbb::concurrent_unordered_map<std::string, std::shared_ptr<PreparedPlan>> _prepared_plans{INITIAL_MAP_SIZE};
 
-  void persist_chunks_to_disk(std::vector<std::shared_ptr<Chunk>> chunks, std::string file_name);
-  file_header read_file_header(std::string filename);
-
  private:
   static const uint32_t CHUNK_COUNT = 50;
+  uint32_t STORAGE_FORMAT_VERSION_ID = 1;
 
   // Fileformat constants
   // File Header
@@ -114,6 +125,8 @@ class StorageManager : public Noncopyable {
   uint32_t ELEMENT_COUNT_BYTES = 4;
   uint32_t COMPRESSED_VECTOR_TYPE_ID_BYTES = 4;
   uint32_t SEGMENT_HEADER_BYTES = DICTIONARY_SIZE_BYTES + ELEMENT_COUNT_BYTES + COMPRESSED_VECTOR_TYPE_ID_BYTES;
+
+  chunk_header read_chunk_header(const std::string filename, const uint32_t segment_count, const uint32_t chunk_offset_begin);
 
   std::vector<uint32_t> generate_segment_offset_ends(const std::shared_ptr<Chunk> chunk);
   void write_dict_segment_to_disk(const std::shared_ptr<DictionarySegment<int>> segment, std::string file_name);

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -35,6 +35,8 @@ struct chunk_header {
   std::vector<uint32_t> segment_offset_ends;
 };
 
+enum ENCODING_TYPE {NO_ENCODING = 0, DICT_ENCODING_8_BYTE = 1, DICT_ENCODING_16_BYTE = 2};
+
 // The StorageManager is a class that maintains all tables
 // by mapping table names to table instances.
 class StorageManager : public Noncopyable {

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -17,10 +17,6 @@
 #include "types.hpp"
 
 #include "storage/dictionary_segment.hpp"
-#include "storage/value_segment.hpp"
-#include "storage/base_dictionary_segment.hpp"
-#include "storage/create_iterable_from_segment.hpp"
-#include "storage/dictionary_segment/dictionary_segment_iterable.hpp"
 
 namespace hyrise {
 
@@ -113,7 +109,7 @@ class StorageManager : public Noncopyable {
   const uint32_t CHUNK_COUNT_BYTES = 2;
   const uint32_t CHUNK_ID_BYTES = 4;
   const uint32_t CHUNK_OFFSET_BYTES = 4;
-  [[maybe_unused]] const uint32_t FILE_HEADER_BYTES = FORMAT_VERSION_ID_BYTES + CHUNK_COUNT_BYTES + CHUNK_COUNT * CHUNK_ID_BYTES + CHUNK_COUNT * CHUNK_OFFSET_BYTES;
+  const uint32_t FILE_HEADER_BYTES = FORMAT_VERSION_ID_BYTES + CHUNK_COUNT_BYTES + CHUNK_COUNT * CHUNK_ID_BYTES + CHUNK_COUNT * CHUNK_OFFSET_BYTES;
 
   // Chunk Header
   const uint32_t ROW_COUNT_BYTES = 4;

--- a/src/test/lib/storage/storage_manager_test.cpp
+++ b/src/test/lib/storage/storage_manager_test.cpp
@@ -265,15 +265,16 @@ std::shared_ptr<Chunk> create_dictionary_segment_chunk(const uint32_t row_count,
 
 TEST_F(StorageManagerTest, WriteMaxNumberOfChunksToFile) {
   const auto file_name = "test_chunks_file.bin";
+  std::remove(file_name);
   auto& sm = Hyrise::get().storage_manager;
 
-  const auto ROW_COUNT = uint32_t{100};
-  const auto COLUMN_COUNT = uint32_t{10};
+  const auto ROW_COUNT = uint32_t{65000}; // fails when set to 100
+  const auto COLUMN_COUNT = uint32_t{23};
   const auto CHUNK_COUNT = sm.get_max_chunk_count();
 
   const auto chunk = create_dictionary_segment_chunk(ROW_COUNT, COLUMN_COUNT);
   std::vector<std::shared_ptr<Chunk>> chunks(CHUNK_COUNT);
-  for (auto i = 0u; i < chunks.size(); ++i) {
+  for (auto i = size_t{0}; i < chunks.size(); ++i) {
     chunks[i] = chunk;
   }
   sm.persist_chunks_to_disk(chunks, file_name);

--- a/src/test/lib/storage/storage_manager_test.cpp
+++ b/src/test/lib/storage/storage_manager_test.cpp
@@ -268,14 +268,14 @@ TEST_F(StorageManagerTest, WriteMaxNumberOfChunksToFile) {
   std::remove(file_name);
   auto& sm = Hyrise::get().storage_manager;
 
-  const auto ROW_COUNT = uint32_t{100}; // can't be greater than INT32_MAX
+  const auto ROW_COUNT = uint32_t{65000}; // can't be greater than INT32_MAX
   const auto COLUMN_COUNT = uint32_t{23};
-  const auto CHUNK_COUNT = sm.get_max_chunk_count();
+  const auto CHUNK_COUNT = sm.get_max_chunk_count_per_file();
 
   const auto chunk = create_dictionary_segment_chunk(ROW_COUNT, COLUMN_COUNT);
   std::vector<std::shared_ptr<Chunk>> chunks(CHUNK_COUNT);
-  for (auto i = size_t{0}; i < chunks.size(); ++i) {
-    chunks[i] = chunk;
+  for (auto index = size_t{0}; index < chunks.size(); ++index) {
+    chunks[index] = chunk;
   }
   sm.persist_chunks_to_disk(chunks, file_name);
 
@@ -306,7 +306,7 @@ TEST_F(StorageManagerTest, WriteMaxNumberOfChunksToFile) {
     });
   });
 
-  const auto mapped_dictionary_segment = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunks[3]->get_segment(ColumnID{16}));
+  const auto mapped_dictionary_segment = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunks[0]->get_segment(ColumnID{16}));
   auto mapped_dict_segment_iterable = create_iterable_from_segment<int>(*mapped_dictionary_segment);
 
   auto column_sum_of_mapped_chunk = uint64_t{};

--- a/src/test/lib/storage/storage_manager_test.cpp
+++ b/src/test/lib/storage/storage_manager_test.cpp
@@ -270,75 +270,7 @@ std::shared_ptr<Chunk> create_dictionary_segment_chunk(const uint32_t row_count,
 }
 
 TEST_F(StorageManagerTest, WritesChunkToFileFormat) {
-  static const int CHUNK_COUNT = 50;
-  const static auto COLUMN_COUNT = uint32_t{23};
-  const static auto ROW_COUNT = uint32_t{65'000};
-  const auto CREATE_COUNT = uint32_t{4};
-
-  auto& sm = Hyrise::get().storage_manager;
-
-  auto chunks = std::vector<std::shared_ptr<Chunk>>{};
-
-  for (auto index = size_t{0}; index < CREATE_COUNT; ++index) {
-    chunks.emplace_back(create_dictionary_segment_chunk(ROW_COUNT, COLUMN_COUNT));
-  }
-
-  sm.prepare_filestream();
-  sm.persist_chunks_to_disk(chunks);
-  sm.end_filestream();
-
-  std::cout << "Data written to disc." << std::endl;
-
-  //TODO: Why read header again before the chunk file is written completely?
-  file_header read_header = read_file_header(FILENAME);
-
-  std::cout << "Chunks written."  << std::endl;
-
-  auto mapped_chunks = std::vector<std::shared_ptr<Chunk>>{};
-  for (auto index = size_t{0}; index < CREATE_COUNT; ++index) {
-    if (index == 0) {
-      mapped_chunks.emplace_back(map_chunk_from_disk(sizeof(file_header)));
-    } else {
-      mapped_chunks.emplace_back(map_chunk_from_disk(read_header.chunk_offset_ends[index - 1]));
-    }
-  }
-  const auto dict_segment_16 = dynamic_pointer_cast<DictionarySegment<int>>(chunks[0]->get_segment(ColumnID{16}));
-  auto dict_segment_iterable = create_iterable_from_segment<int>(*dict_segment_16);
-
-  auto column_sum_of_created_chunk = uint64_t{};
-  dict_segment_iterable.with_iterators([&](auto it, auto end) {
-    column_sum_of_created_chunk = std::accumulate(it, end, uint64_t{0}, [](const auto& accumulator, const auto& currentValue) {
-      return accumulator + currentValue.value();
-    });
-  });
-
-  std::cout << "Sum of column 17 of created chunk: " << column_sum_of_created_chunk << std::endl;
-
-  const auto mapped_dictionary_segment = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunks[3]->get_segment(ColumnID{16}));
-  auto mapped_dict_segment_iterable = create_iterable_from_segment<int>(*mapped_dictionary_segment);
-
-  auto column_sum_of_mapped_chunk = uint64_t{};
-  mapped_dict_segment_iterable.with_iterators([&](auto it, auto end) {
-    column_sum_of_mapped_chunk = std::accumulate(it, end, uint64_t{0}, [](const auto& accumulator, const auto& currentValue) {
-      return accumulator + currentValue.value();
-    });
-  });
-
-  std::cout << "Sum of column 17 of third mapped chunk: " << column_sum_of_mapped_chunk << std::endl;
-
-  std::cout << "Col 0 of created chunk: ";
-  const auto original_dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(chunks[0]->get_segment(ColumnID{0}));
-  for (auto row_index = ChunkOffset{0}; row_index < 20; ++row_index) {
-    std::cout << (original_dict_segment->get_typed_value(row_index)).value() << " ";
-  }
-  std::cout << std::endl;
-
-  std::cout << "Col 0 of third mapped chunk: ";
-  const auto original_dict_segment1 = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunks[3]->get_segment(ColumnID{0}));
-  for (auto row_index = ChunkOffset{0}; row_index < 20; ++row_index) {
-    std::cout << (original_dict_segment1->get_typed_value(row_index)).value() << " ";
-  }
-  std::cout << std::endl;
+  EXPECT_TRUE(true);
 }
 
 

--- a/src/test/lib/storage/storage_manager_test.cpp
+++ b/src/test/lib/storage/storage_manager_test.cpp
@@ -268,7 +268,7 @@ TEST_F(StorageManagerTest, WriteMaxNumberOfChunksToFile) {
   std::remove(file_name);
   auto& sm = Hyrise::get().storage_manager;
 
-  const auto ROW_COUNT = uint32_t{65000}; // fails when set to 100
+  const auto ROW_COUNT = uint32_t{100}; // can't be greater than INT32_MAX
   const auto COLUMN_COUNT = uint32_t{23};
   const auto CHUNK_COUNT = sm.get_max_chunk_count();
 

--- a/src/test/lib/storage/storage_manager_test.cpp
+++ b/src/test/lib/storage/storage_manager_test.cpp
@@ -240,17 +240,11 @@ std::shared_ptr<Chunk> create_dictionary_segment_chunk(const uint32_t row_count,
    * Dictionary-encode each segment and return dictionary encoded chunk.
    */
   auto segments = pmr_vector<std::shared_ptr<AbstractSegment>>{};
-  const auto num_values = int64_t{column_count * row_count};
-
-  std::cout << "We create a dictionary-encoded chunk with " << column_count << " columns, " << row_count << " rows and thus "
-            << num_values << " values." << std::endl;
-
   for (auto segment_index = uint32_t{0}; segment_index < column_count; ++segment_index) {
     auto new_value_segment = std::make_shared<ValueSegment<int32_t>>();
 
     auto current_value = int32_t{65'000};
     auto value_count = uint32_t{1}; //start 1-indexed to avoid issues with modulo operations
-
     while (value_count - 1 < row_count) { //as we start 1-indexed we need to adapt while-condition to create row-count many elements
       new_value_segment->append(current_value);
 
@@ -269,9 +263,60 @@ std::shared_ptr<Chunk> create_dictionary_segment_chunk(const uint32_t row_count,
   return dictionary_encoded_chunk;
 }
 
-TEST_F(StorageManagerTest, WritesChunkToFileFormat) {
-  EXPECT_TRUE(true);
-}
+TEST_F(StorageManagerTest, WriteMaxNumberOfChunksToFile) {
+  const auto file_name = "test_chunks_file.bin";
+  auto& sm = Hyrise::get().storage_manager;
 
+  const auto ROW_COUNT = uint32_t{100};
+  const auto COLUMN_COUNT = uint32_t{10};
+  const auto CHUNK_COUNT = sm.get_max_chunk_count();
+
+  const auto chunk = create_dictionary_segment_chunk(ROW_COUNT, COLUMN_COUNT);
+  std::vector<std::shared_ptr<Chunk>> chunks(CHUNK_COUNT);
+  for (auto i = 0u; i < chunks.size(); ++i) {
+    chunks[i] = chunk;
+  }
+  sm.persist_chunks_to_disk(chunks, file_name);
+
+  EXPECT_TRUE(std::filesystem::exists(file_name));
+
+  const auto read_header = sm.read_file_header(file_name);
+
+  EXPECT_EQ(read_header.chunk_count, CHUNK_COUNT);
+  EXPECT_EQ(read_header.storage_format_version_id, sm.get_storage_format_version_id());
+  EXPECT_EQ(read_header.chunk_ids.size(), CHUNK_COUNT);
+  EXPECT_EQ(read_header.chunk_offset_ends.size(), CHUNK_COUNT);
+
+  auto mapped_chunks = std::vector<std::shared_ptr<Chunk>>{};
+  for (auto index = size_t{0}; index < CHUNK_COUNT; ++index) {
+    if (index == 0) {
+      mapped_chunks.emplace_back(sm.map_chunk_from_disk(sizeof(file_header), file_name, COLUMN_COUNT));
+    } else {
+      mapped_chunks.emplace_back(sm.map_chunk_from_disk(read_header.chunk_offset_ends[index - 1], file_name, COLUMN_COUNT));
+    }
+  }
+  const auto dict_segment_16 = dynamic_pointer_cast<DictionarySegment<int>>(chunks[0]->get_segment(ColumnID{16}));
+  auto dict_segment_iterable = create_iterable_from_segment<int>(*dict_segment_16);
+
+  auto column_sum_of_created_chunk = uint64_t{};
+  dict_segment_iterable.with_iterators([&](auto it, auto end) {
+    column_sum_of_created_chunk = std::accumulate(it, end, uint64_t{0}, [](const auto& accumulator, const auto& currentValue) {
+      return accumulator + currentValue.value();
+    });
+  });
+
+  const auto mapped_dictionary_segment = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunks[3]->get_segment(ColumnID{16}));
+  auto mapped_dict_segment_iterable = create_iterable_from_segment<int>(*mapped_dictionary_segment);
+
+  auto column_sum_of_mapped_chunk = uint64_t{};
+  mapped_dict_segment_iterable.with_iterators([&](auto it, auto end) {
+    column_sum_of_mapped_chunk = std::accumulate(it, end, uint64_t{0}, [](const auto& accumulator, const auto& currentValue) {
+      return accumulator + currentValue.value();
+    });
+  });
+  
+  EXPECT_EQ(column_sum_of_created_chunk, column_sum_of_mapped_chunk);
+
+}
 
 }  // namespace hyrise

--- a/src/test/lib/storage/storage_manager_test.cpp
+++ b/src/test/lib/storage/storage_manager_test.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <numeric>
 
 #include "base_test.hpp"
 
@@ -231,5 +232,114 @@ TEST_F(StorageManagerTest, HasPreparedPlan) {
   auto& sm = Hyrise::get().storage_manager;
   EXPECT_EQ(sm.has_prepared_plan("first_prepared_plan"), true);
 }
+
+std::shared_ptr<Chunk> create_dictionary_segment_chunk(const uint32_t row_count, const uint32_t column_count) {
+  /*
+   * Create a chunk with index-times repeating elements in each segment.
+   * Example: in segment 0 every value is unique, in segment 1 every value appears twice, in segment 2 thrice ...
+   * Dictionary-encode each segment and return dictionary encoded chunk.
+   */
+  auto segments = pmr_vector<std::shared_ptr<AbstractSegment>>{};
+  const auto num_values = int64_t{column_count * row_count};
+
+  std::cout << "We create a dictionary-encoded chunk with " << column_count << " columns, " << row_count << " rows and thus "
+            << num_values << " values." << std::endl;
+
+  for (auto segment_index = uint32_t{0}; segment_index < column_count; ++segment_index) {
+    auto new_value_segment = std::make_shared<ValueSegment<int32_t>>();
+
+    auto current_value = int32_t{65'000};
+    auto value_count = uint32_t{1}; //start 1-indexed to avoid issues with modulo operations
+
+    while (value_count - 1 < row_count) { //as we start 1-indexed we need to adapt while-condition to create row-count many elements
+      new_value_segment->append(current_value);
+
+      //create segment-index many duplicates of each value in the segment
+      if (value_count % (segment_index + 1) == 0) {
+        --current_value;
+      }
+      ++value_count;
+    }
+
+    auto ds_int = ChunkEncoder::encode_segment(new_value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
+    segments.emplace_back(ds_int);
+  }
+
+  const auto dictionary_encoded_chunk = std::make_shared<Chunk>(segments);
+  return dictionary_encoded_chunk;
+}
+
+TEST_F(StorageManagerTest, WritesChunkToFileFormat) {
+  static const int CHUNK_COUNT = 50;
+  const static auto COLUMN_COUNT = uint32_t{23};
+  const static auto ROW_COUNT = uint32_t{65'000};
+  const auto CREATE_COUNT = uint32_t{4};
+
+  auto& sm = Hyrise::get().storage_manager;
+
+  auto chunks = std::vector<std::shared_ptr<Chunk>>{};
+
+  for (auto index = size_t{0}; index < CREATE_COUNT; ++index) {
+    chunks.emplace_back(create_dictionary_segment_chunk(ROW_COUNT, COLUMN_COUNT));
+  }
+
+  sm.prepare_filestream();
+  sm.persist_chunks_to_disk(chunks);
+  sm.end_filestream();
+
+  std::cout << "Data written to disc." << std::endl;
+
+  //TODO: Why read header again before the chunk file is written completely?
+  file_header read_header = read_file_header(FILENAME);
+
+  std::cout << "Chunks written."  << std::endl;
+
+  auto mapped_chunks = std::vector<std::shared_ptr<Chunk>>{};
+  for (auto index = size_t{0}; index < CREATE_COUNT; ++index) {
+    if (index == 0) {
+      mapped_chunks.emplace_back(map_chunk_from_disk(sizeof(file_header)));
+    } else {
+      mapped_chunks.emplace_back(map_chunk_from_disk(read_header.chunk_offset_ends[index - 1]));
+    }
+  }
+  const auto dict_segment_16 = dynamic_pointer_cast<DictionarySegment<int>>(chunks[0]->get_segment(ColumnID{16}));
+  auto dict_segment_iterable = create_iterable_from_segment<int>(*dict_segment_16);
+
+  auto column_sum_of_created_chunk = uint64_t{};
+  dict_segment_iterable.with_iterators([&](auto it, auto end) {
+    column_sum_of_created_chunk = std::accumulate(it, end, uint64_t{0}, [](const auto& accumulator, const auto& currentValue) {
+      return accumulator + currentValue.value();
+    });
+  });
+
+  std::cout << "Sum of column 17 of created chunk: " << column_sum_of_created_chunk << std::endl;
+
+  const auto mapped_dictionary_segment = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunks[3]->get_segment(ColumnID{16}));
+  auto mapped_dict_segment_iterable = create_iterable_from_segment<int>(*mapped_dictionary_segment);
+
+  auto column_sum_of_mapped_chunk = uint64_t{};
+  mapped_dict_segment_iterable.with_iterators([&](auto it, auto end) {
+    column_sum_of_mapped_chunk = std::accumulate(it, end, uint64_t{0}, [](const auto& accumulator, const auto& currentValue) {
+      return accumulator + currentValue.value();
+    });
+  });
+
+  std::cout << "Sum of column 17 of third mapped chunk: " << column_sum_of_mapped_chunk << std::endl;
+
+  std::cout << "Col 0 of created chunk: ";
+  const auto original_dict_segment = dynamic_pointer_cast<DictionarySegment<int>>(chunks[0]->get_segment(ColumnID{0}));
+  for (auto row_index = ChunkOffset{0}; row_index < 20; ++row_index) {
+    std::cout << (original_dict_segment->get_typed_value(row_index)).value() << " ";
+  }
+  std::cout << std::endl;
+
+  std::cout << "Col 0 of third mapped chunk: ";
+  const auto original_dict_segment1 = dynamic_pointer_cast<DictionarySegment<int>>(mapped_chunks[3]->get_segment(ColumnID{0}));
+  for (auto row_index = ChunkOffset{0}; row_index < 20; ++row_index) {
+    std::cout << (original_dict_segment1->get_typed_value(row_index)).value() << " ";
+  }
+  std::cout << std::endl;
+}
+
 
 }  // namespace hyrise

--- a/src/test/lib/storage/storage_manager_test_util.cpp
+++ b/src/test/lib/storage/storage_manager_test_util.cpp
@@ -1,0 +1,43 @@
+#include <memory>
+
+#include "hyrise.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+#include "storage/table.hpp"
+
+namespace hyrise {
+
+class StorageManagerTestUtil {
+ public:
+  static std::shared_ptr<Chunk> create_dictionary_segment_chunk(const uint32_t row_count, const uint32_t column_count) {
+    /*
+   * Create a chunk with index-times repeating elements in each segment.
+   * Example: in segment 0 every value is unique, in segment 1 every value appears twice, in segment 2 thrice ...
+   * Dictionary-encode each segment and return dictionary encoded chunk.
+   */
+    auto segments = pmr_vector<std::shared_ptr<AbstractSegment>>{};
+    for (auto segment_index = uint32_t{0}; segment_index < column_count; ++segment_index) {
+      auto new_value_segment = std::make_shared<ValueSegment<int32_t>>();
+
+      auto current_value = static_cast<int32_t>(row_count);
+      auto value_count = uint32_t{1}; //start 1-indexed to avoid issues with modulo operations
+      while (value_count - 1 < row_count) { //as we start 1-indexed we need to adapt while-condition to create row-count many elements
+        new_value_segment->append(current_value);
+
+        //create segment-index many duplicates of each value in the segment
+        if (value_count % (segment_index + 1) == 0) {
+          --current_value;
+        }
+        ++value_count;
+      }
+
+      auto ds_int = ChunkEncoder::encode_segment(new_value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
+      segments.emplace_back(ds_int);
+    }
+
+    const auto dictionary_encoded_chunk = std::make_shared<Chunk>(segments);
+    return dictionary_encoded_chunk;
+  }
+
+};
+
+}  // namespace hyrise

--- a/src/test/lib/storage/storage_manager_test_util.cpp
+++ b/src/test/lib/storage/storage_manager_test_util.cpp
@@ -19,8 +19,9 @@ class StorageManagerTestUtil {
       auto new_value_segment = std::make_shared<ValueSegment<int32_t>>();
 
       auto current_value = static_cast<int32_t>(row_count);
-      auto value_count = uint32_t{1}; //start 1-indexed to avoid issues with modulo operations
-      while (value_count - 1 < row_count) { //as we start 1-indexed we need to adapt while-condition to create row-count many elements
+      auto value_count = uint32_t{1};  //start 1-indexed to avoid issues with modulo operations
+      while (value_count - 1 <
+             row_count) {  //as we start 1-indexed we need to adapt while-condition to create row-count many elements
         new_value_segment->append(current_value);
 
         //create segment-index many duplicates of each value in the segment
@@ -30,14 +31,14 @@ class StorageManagerTestUtil {
         ++value_count;
       }
 
-      auto ds_int = ChunkEncoder::encode_segment(new_value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
+      auto ds_int =
+          ChunkEncoder::encode_segment(new_value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
       segments.emplace_back(ds_int);
     }
 
     const auto dictionary_encoded_chunk = std::make_shared<Chunk>(segments);
     return dictionary_encoded_chunk;
   }
-
 };
 
 }  // namespace hyrise


### PR DESCRIPTION
This PR moves the playground code to the storage manager so that we can finally work in hyrise. Added to that, we included a test in our changes that verifies what we've already testes in the playground (sum of row 17 or smth)

The test can be run using  ./hyriseTest --gtest_filter=StorageManagerTest.WriteMaxNumberOfChunksToFile after running ninja

